### PR TITLE
fix: 优化sentenceLayout的兜底分割方式

### DIFF
--- a/src/utils/lyrics/sentenceLayout.ts
+++ b/src/utils/lyrics/sentenceLayout.ts
@@ -429,9 +429,67 @@ class SentenceLayout implements LyricLayoutUnit {
 
     private static secondarySplit(sentences: SentenceLayout[], targetCount: number, timeSeed?: number): SentenceLayout[] {
         const Segmenter = Intl?.Segmenter;
+        const segmenter = Segmenter ? new Segmenter(undefined, { granularity: 'word' }) : null;
+
         while (sentences.length < targetCount) {
             const candidates = sentences.filter(s => s.text.length > 2);
             if (candidates.length === 0) break;
+
+            if (segmenter) {
+                const semanticCandidates: { sentence: SentenceLayout; index: number; splitPos: number; score: number }[] = [];
+
+                for (const s of candidates) {
+                    try {
+                        const segments = Array.from(
+                            segmenter.segment(s.text)
+                        );
+
+                        const wordPositions: { start: number; end: number }[] = [];
+                        let offset = 0;
+                        for (const seg of segments) {
+                            if (seg.isWordLike) {
+                                wordPositions.push({ start: offset, end: offset + seg.segment.length });
+                            }
+                            offset += seg.segment.length;
+                        }
+
+                        if (wordPositions.length >= 2) {
+                            const midChar = s.text.length / 2;
+                            let bestGapIdx = 1;
+                            let bestDist = Infinity;
+                            for (let g = 1; g < wordPositions.length; g++) {
+                                const dist = Math.abs(wordPositions[g].start - midChar);
+                                if (dist < bestDist) {
+                                    bestDist = dist;
+                                    bestGapIdx = g;
+                                }
+                            }
+
+                            const splitPos = wordPositions[bestGapIdx].start;
+                            const balanceScore = 1 - Math.abs(splitPos - midChar) / midChar;
+
+                            semanticCandidates.push({
+                                sentence: s,
+                                index: sentences.indexOf(s),
+                                splitPos,
+                                score: balanceScore * 10 + wordPositions.length,
+                            });
+                        }
+                    } catch { }
+                }
+
+                if (semanticCandidates.length > 0) {
+                    semanticCandidates.sort((a, b) => b.score - a.score);
+                    const best = semanticCandidates[0];
+                    const firstHalf = best.sentence.text.slice(0, best.splitPos);
+                    const secondHalf = best.sentence.text.slice(best.splitPos);
+                    sentences.splice(best.index, 1,
+                        new SentenceLayout(firstHalf),
+                        new SentenceLayout(secondHalf)
+                    );
+                    continue;
+                }
+            }
 
             const pseudoRandom = (seed: number) => {
                 const x = Math.sin(seed) * 10000;
@@ -444,65 +502,9 @@ class SentenceLayout implements LyricLayoutUnit {
             const selectedCandidate = candidates[randomIndex];
             const candidateIndex = sentences.indexOf(selectedCandidate);
 
-            let firstHalf: string;
-            let secondHalf: string;
-
-            if (Segmenter) {
-                try {
-                    const segments = Array.from(new Segmenter(undefined, { granularity: 'word' }).segment(selectedCandidate.text));
-                    const midChar = selectedCandidate.text.length / 2;
-                    let splitAfter = -1;
-                    let accumulated = 0;
-                    for (let i = 0; i < segments.length; i++) {
-                        accumulated += segments[i].segment.length;
-                        if (accumulated >= midChar) {
-                            splitAfter = i;
-                            break;
-                        }
-                    }
-                    if (splitAfter > 0 && splitAfter < segments.length) {
-                        const wordPositions: { start: number; end: number }[] = [];
-                        let offset = 0;
-                        for (const s of segments) {
-                            if (s.isWordLike) {
-                                wordPositions.push({ start: offset, end: offset + s.segment.length });
-                            }
-                            offset += s.segment.length;
-                        }
-                        if (wordPositions.length >= 2) {
-                            const midChar = selectedCandidate.text.length / 2;
-                            let bestGapIdx = 1;
-                            let bestDist = Infinity;
-                            for (let g = 1; g < wordPositions.length; g++) {
-                                const dist = Math.abs(wordPositions[g].start - midChar);
-                                if (dist < bestDist) {
-                                    bestDist = dist;
-                                    bestGapIdx = g;
-                                }
-                            }
-                            const splitPos = wordPositions[bestGapIdx].start;
-                            firstHalf = selectedCandidate.text.slice(0, splitPos);
-                            secondHalf = selectedCandidate.text.slice(splitPos);
-                        } else {
-                            const midPoint = Math.floor(selectedCandidate.text.length / 2);
-                            firstHalf = selectedCandidate.text.slice(0, midPoint);
-                            secondHalf = selectedCandidate.text.slice(midPoint);
-                        }
-                    } else {
-                        const midPoint = Math.floor(selectedCandidate.text.length / 2);
-                        firstHalf = selectedCandidate.text.slice(0, midPoint);
-                        secondHalf = selectedCandidate.text.slice(midPoint);
-                    }
-                } catch {
-                    const midPoint = Math.floor(selectedCandidate.text.length / 2);
-                    firstHalf = selectedCandidate.text.slice(0, midPoint);
-                    secondHalf = selectedCandidate.text.slice(midPoint);
-                }
-            } else {
-                const midPoint = Math.floor(selectedCandidate.text.length / 2);
-                firstHalf = selectedCandidate.text.slice(0, midPoint);
-                secondHalf = selectedCandidate.text.slice(midPoint);
-            }
+            const midPoint = Math.floor(selectedCandidate.text.length / 2);
+            const firstHalf = selectedCandidate.text.slice(0, midPoint);
+            const secondHalf = selectedCandidate.text.slice(midPoint);
 
             sentences.splice(candidateIndex, 1,
                 new SentenceLayout(firstHalf),


### PR DESCRIPTION
fix #60 

顺带把sentenceLayout到底做了什么做一下总结

整个拆分流程分为 **三个阶段**：

---

### 一、主拆分阶段（Level 1–5 递进式）

`splitIntoSentences` 根据 `targetCount` 确定最大层级数 `maxLevel`，**逐层**对所有已有片段执行 `splitByLevel`，每层只在上一层的拆分结果上继续细分：

| Level | 方法 | 拆分依据 | 用途 |
|-------|------|----------|------|
| **1** | `splitByPunctuation` | 标点符号 `，。；！？、…·.;,!?` | 以完整标点为界做最天然的分句 |
| **2** | `splitByBracketsQuotes` | 成对符号 `「」『』《》【】｛｝［］[]（）() "" ''` | 以封闭符号划分语义块 |
| **3** | `splitByWesternWords` | 西文连续单词块（多个西文单词组成的短语） | 在 东西混合的文字中分离出西文（也就分离了cjk） |
| **4** | `splitCJKBySpace` | 空格 | 拆分 CJK 部分内的空格（如果直接拆分全部中英文空格，会让结果太碎） |
| **5** | `splitBySpecialChars` | 特殊分隔符 `：:/\|｜~～` | 这些字符前后的内容往往更加紧密，因此做最终粒度拆分 |

**关键行为**：
1. 每次拆分都会先检查当前片段数是否已满足 `targetCount`，满足则提前终止。
2. 如果使用负数，可以指定到拆分的层级，即-3拆分到第三层
3. 除成对符号外，所有切分都让空格、符号跟随到左侧的片段


---

### 二、补充分割阶段（secondarySplit）

当主拆分后片段数**少于** `targetCount` 时触发。此次的问题就出现在这个阶段。
修复之后英文可以在单词边界拆分，cjk的拆分要差一点（但是符号已经拆过一次了，大概率不会触发太难堪的场景）
基于不加载额外字典的前提，并不能做到太好。

---

### 三、合并阶段（mergeSentences）

当拆分后片段数**多于** `targetCount` 时触发

---
