### PR TITLE
feat: 为 macOS 桌面端添加 Intel 支持

### DIFF
--- a/.github/workflows/macos-canary-pre-release.yml
+++ b/.github/workflows/macos-canary-pre-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Package Electron App for macOS
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
-        run: npx electron-builder --mac dmg zip --publish never
+        run: npx electron-builder --mac --x64 --arm64 --publish never
 
       - name: Upload packaged artifacts
         uses: actions/upload-artifact@v6

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -39,6 +39,13 @@ if (process.platform === 'linux') {
   }
 }
 
+// macOS: GPU 加速优化，解决 Intel Mac + AMD 独显在 Retina 屏幕下的渲染卡顿
+if (process.platform === 'darwin' && process.arch === 'x64') {
+  app.commandLine.appendSwitch('ignore-gpu-blocklist');
+  app.commandLine.appendSwitch('use-angle', 'gl');
+  app.commandLine.appendSwitch('enable-gpu-rasterization');
+}
+
 const store = new Store({ projectName: 'Folia' });
 let mainWindow = null;
 let remoteControlWindow = null;

--- a/package.json
+++ b/package.json
@@ -83,9 +83,23 @@
     ],
     "mac": {
       "target": [
-        "dmg"
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
-      "icon": "build/icon.png"
+      "icon": "build/icon.png",
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
     },
     "win": {
       "artifactName": "${productName}-Setup-${version}.${ext}",


### PR DESCRIPTION
本项目目前有且仅有Apple Silicon（即arm64架构）的支持，但如今Intel Mac仍然有相当大的使用群体，故增加对Intel Mac的支持并且为Intel Mac做出部分优化。

另外在Intel Mac的Metal下运行Chromium的ANGLE**可能**会出现渲染性能异常的问题，参考：
https://forum.babylonjs.com/t/chrome-mac-extremely-slow/48492/6
https://www.v2ex.com/t/1213774
该问题似乎只会在macOS Sonoma至macOS Sequoia中出现，并且实测在我的环境上出现了该问题
<img width="1124" height="776" alt="image" src="https://github.com/user-attachments/assets/0f7f4401-bc2e-4f91-84d2-04510a6b26bc" />
所以针对Intel Mac不使用Metal进行渲染而使用OpenGL，但是否在macOS Tahoe上存在该问题仍需要进一步考证。