### PR TITLE
fix: 修复群唱(Cappella)全角歌词临界换行时末字被 overflow 裁切

### DIFF
--- a/src/components/visualizer/cappella/VisualizerCappella.tsx
+++ b/src/components/visualizer/cappella/VisualizerCappella.tsx
@@ -1438,7 +1438,7 @@ const CappellaMessageRow = React.forwardRef<HTMLDivElement, CappellaMessageRowPr
                                 color: bubbleColors.textColor,
                                 fontSize: bubbleFontSize,
                                 lineHeight: 1.45,
-                                maxWidth: maxTextWidth + bubblePaddingX * 2 + cappellaBubbleRenderSafetyPx(bubbleFontSize),
+                                maxWidth: maxTextWidth + bubblePaddingX * 2 + cappellaBubbleRenderSafetyPx(bubbleFontSize) + 2,
                                 minHeight: Math.max(
                                     isActiveMessage ? motionConfig.activeMinHeight : motionConfig.inactiveMinHeight,
                                     bubbleFontSize * 1.45 + bubblePaddingY * 2

--- a/src/components/visualizer/cappella/VisualizerCappella.tsx
+++ b/src/components/visualizer/cappella/VisualizerCappella.tsx
@@ -76,6 +76,12 @@ const CAPPELLA_LAYOUT_CACHE_LIMIT = 32;
 // 让横向扩展先于字符出现启动，避免临界换行时字符短暂掉到下一行。
 const CAPPELLA_WIDTH_LOOKAHEAD_SECONDS = 0.2;
 const CAPPELLA_BUBBLE_TEXT_OPTIONS = { whiteSpace: 'pre-wrap' } satisfies PrepareOptions;
+// ActiveCappellaText 渲染时把每个字拆成独立的 inline-block 放进 flex-wrap 行，
+// 失去字距且每字宽度各自向上取整，所以 DOM 实际行宽比下面 canvas 连续文本的量度略大。
+// 差值足以令「量度为一行」的歌词在渲染时把最后一个字挤到第二行，而气泡高度只按量度
+// 的行数预留，第二行便被 overflow:hidden 裁掉半个字（QRC 全角日文/中文尤其明显）。
+// 预留一点横向安全余量，让渲染行始终容得下其高度所对应的宽度。
+const cappellaBubbleRenderSafetyPx = (fontSize: number) => Math.max(6, Math.ceil(fontSize * 0.35));
 
 interface BubbleSize {
     width: number;
@@ -846,6 +852,7 @@ const measureBubbleText = ({
     return {
         width: Math.ceil(
             Math.min(textWidth, maxTextWidth)
+            + cappellaBubbleRenderSafetyPx(fontSize)
             + paddingX * 2
             + bubbleBorderWidth * 2
         ),
@@ -1431,7 +1438,7 @@ const CappellaMessageRow = React.forwardRef<HTMLDivElement, CappellaMessageRowPr
                                 color: bubbleColors.textColor,
                                 fontSize: bubbleFontSize,
                                 lineHeight: 1.45,
-                                maxWidth: maxTextWidth + bubblePaddingX * 2,
+                                maxWidth: maxTextWidth + bubblePaddingX * 2 + cappellaBubbleRenderSafetyPx(bubbleFontSize),
                                 minHeight: Math.max(
                                     isActiveMessage ? motionConfig.activeMinHeight : motionConfig.inactiveMinHeight,
                                     bubbleFontSize * 1.45 + bubblePaddingY * 2


### PR DESCRIPTION
## 问题

Fixes #172

群唱（Cappella）样式下，当前播放行遇到「刚好落在气泡宽度临界」的全角（日文/中文）歌词时，最后一个字会被挤到第二行并被 `overflow:hidden` 裁掉约一半（只露出顶部）。多次播放会在不同句子上间歇出现；与已修复的 #74 不同，本例即使收缩为非 active 后仍维持两行，不属于「字号缩小产生的预期结果」。

## 根因

`ActiveCappellaText` 将每个字渲染为独立的 `inline-block`，置于 `inline-flex flex-wrap` 行。每个 `inline-block` 的宽度各自向上取整（连排时的字距也一并丢失），导致 DOM 实际行宽比 `measureBubbleText` 中用文本测量得到的连续文本宽度**略大**。于是量度判定「一行放得下」→ 气泡只按量度的行数（1 行）预留高度 → 渲染时末字换到第二行并被 `overflow:hidden` 裁掉。CJK 全角文本逐字断行、无单词边界，尤其容易踩中这个临界点。

已排除空格因素：目标行原始 QRC 结尾无空格 token（同一首歌其他行确有中间空格 token，但目标行不含）。

## 修改

在 `measureBubbleText` 计算气泡宽度时预留一点横向安全余量 `cappellaBubbleRenderSafetyPx`，并同步放宽气泡的 `maxWidth` 上限，避免安全余量被 CSS 夹回抵消，使逐字渲染的实际行宽不超过其高度所对应的宽度，渲染行数恒 ≤ 量度行数。因为修在量度层，对所有落在临界宽度的全角句子一并生效，无需逐句处理。

- `cappellaBubbleRenderSafetyPx(fontSize) = max(6, ceil(fontSize * 0.35))`
- `cappellaBubbleRenderSafetyPx` 与 `measureBubbleText` 均定义、使用于 `VisualizerCappella.tsx` 内，影响范围仅限 Cappella 气泡宽度；气泡视觉上仅略宽约三分之一个字宽（0.35×字号），不影响其他 visualizer。

## 测试

本地 dev 环境播放多首含全角歌词的歌曲（QQ 逐字 QRC），跨歌曲、跨句子间歇复现，修复后均不再出现：

- YOASOBI「舞台に立って」：「見えなくなる」的「る」、「会いに行くんだ」的「だ」、「舞台に立って」的「て」
- 「Reply – kz(livetune) / かぐや(cv.夏吉ゆうこ) from 超かぐや姫！」：「ふさいだ鍵穴」的「穴」、「きみだけの」的「の」
