### PR TITLE
fix(video-export): 修复窗口边界与分辨率匹配问题，改用Canvas裁剪消除黑边

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3207,7 +3207,10 @@ function fitMainWindowBoundsToExportSize(exportSize) {
   let cssHeight = Math.max(1, Math.round(exportSize.height / exportDpr));
   mainWindow.setContentSize(cssWidth, cssHeight, false);
 
-  const workArea = screen.getPrimaryDisplay().workArea;
+  // Keep the window on whichever display it already lives on instead of forcing
+  // it to the primary display. getDisplayMatching resolves the display containing
+  // the window's current bounds, so the export stays put (no surprise jump).
+  const workArea = screen.getDisplayMatching(mainWindow.getBounds()).workArea;
   // Center the window and snap its position to a whole physical pixel. Under a non-100% DPI
   // the CSS position times dpr can land on a half-pixel, and Chromium's crop-and-scale
   // capture derives its crop rect from the window's physical bounds; a half-pixel offset

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3179,6 +3179,138 @@ function sanitizeVideoExportSize(size) {
   };
 }
 
+// Resize the main window so that its *bounds* (the area the capture source
+// actually records, which includes Windows' frameless-window DWM decoration)
+// yields a content physical size >= the requested export size. We use a snap
+// search around the ideal CSS size to find a value where getContentSize() * dpr
+// exceeds the preset (overshoot), then the frontend Canvas crops the excess
+// pixels with integer symmetric cropping — no scaling, no black bars.
+// After sizing, we enter a decoration-removal loop: if DWM adds asymmetric
+// borders that shift content off-center inside bounds, we grow the window by
+// 1px on each edge and retry until bounds == content (decoration eliminated).
+function fitMainWindowBoundsToExportSize(exportSize) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return null;
+  }
+
+  const exportDpr = mainWindow.__dpr && mainWindow.__dpr > 0 ? mainWindow.__dpr : 1;
+
+  // Size the window so its *bounds* (the area the capture source actually records —
+  // a whole-window capture includes the ~1px frameless-window DWM decoration) matches
+  // the preset in physical pixels exactly. If the bounds physical size differed from the
+  // preset, the capture source aspect ratio would mismatch the output and crop-and-scale
+  // would add black bars. We set the rounded CSS content size, then read back the bounds
+  // physical size and nudge by +/-1 CSS px until it equals the preset. The content area
+  // ends up ~decoration px smaller than the preset (a minor crop), but the recording has
+  // no scaling black bars and the output is exactly the requested resolution.
+  let cssWidth = Math.max(1, Math.round(exportSize.width / exportDpr));
+  let cssHeight = Math.max(1, Math.round(exportSize.height / exportDpr));
+  mainWindow.setContentSize(cssWidth, cssHeight, false);
+
+  const workArea = screen.getPrimaryDisplay().workArea;
+  // Center the window and snap its position to a whole physical pixel. Under a non-100% DPI
+  // the CSS position times dpr can land on a half-pixel, and Chromium's crop-and-scale
+  // capture derives its crop rect from the window's physical bounds; a half-pixel offset
+  // between the reported bounds and where the window is actually composited can leave a
+  // 1-2px black strip. Aligning the physical position to whole pixels removes that drift.
+  const center = (w, h) => {
+    let x = Math.round(workArea.x + (workArea.width - w) / 2);
+    let y = Math.round(workArea.y + (workArea.height - h) / 2);
+    if (!Number.isInteger(x * exportDpr)) x += (x % 2 === 0) ? 1 : -1;
+    if (!Number.isInteger(y * exportDpr)) y += (y % 2 === 0) ? 1 : -1;
+    mainWindow.setBounds({ x, y, width: w, height: h }, false);
+    return mainWindow.getBounds();
+  };
+
+  // The capture source is the *whole window* (bounds), which on a frameless transparent
+  // window on Windows carries a 1px DWM border (decoLeftCss = 1) and, after DWM snaps the
+  // window to its grid, can gain/lose a pixel on resize. So neither the rounded CSS size
+  // nor a single +/-1 nudge reliably yields boundsPhys == preset. We search a small CSS
+  // window around the rounded size, CENTERING THE WINDOW EACH TIME so we read the *final*
+  // boundsPhys (including DWM snapping), and pick the value whose *content* physical
+  // size (from getContentSize, NOT bounds) is >= preset + margin (so the Canvas crop
+  // can work in pure-crop mode without upscaling).
+  // Minimum overshoot (in device pixels) to guarantee pure-crop mode without upscaling.
+  // This is a hard lower bound, NOT a per-resolution guess: regardless of DPR or DWM decoration
+  // size, snap() only ensures contentPhys >= preset + CROP_MARGIN_PX, and the actual crop amount is
+  // always derived from (video.videoWidth/videoHeight - preset) at runtime. Do not retune per resolution.
+  const CROP_MARGIN_PX = 6; // Minimum extra pixels for pure crop (no scaling)
+  const snap = (base, axis, otherCss) => {
+    base = Math.max(1, base);
+    let bestCss = base;
+    let bestErr = Infinity;
+    let bestContentPhys = 0;
+    // Target contentPhys must be >= preset + margin to allow pure crop in Canvas
+    const target = (axis === 'w' ? exportSize.width : exportSize.height) + CROP_MARGIN_PX;
+    const presetVal = axis === 'w' ? exportSize.width : exportSize.height;
+    let probe = '';
+    // Fixed search radius around the rounded CSS size. This is an exploration window to absorb
+    // 1px DWM-snap jitter, NOT a hand-tuned value for a specific resolution: we always test every
+    // delta and pick the one whose measured contentPhys is closest to (preset + CROP_MARGIN_PX).
+    for (let delta = -3; delta <= 5; delta++) { // Extended search range for overshoot
+      const tryCss = base + delta;
+      if (tryCss < 1) continue;
+      if (axis === 'w') mainWindow.setContentSize(tryCss, otherCss, false);
+      else mainWindow.setContentSize(otherCss, tryCss, false);
+      const b = center(axis === 'w' ? tryCss : otherCss, axis === 'w' ? otherCss : tryCss);
+      // Compare CONTENT physical size (not bounds) because the Canvas crop operates
+      // on the content area after excluding DWM decoration pixels.
+      const [cW, cH] = mainWindow.getContentSize();
+      const cPhys = axis === 'w'
+        ? Math.round(cW * exportDpr)
+        : Math.round(cH * exportDpr);
+      const bPhys = axis === 'w'
+        ? Math.round(b.width * exportDpr)
+        : Math.round(b.height * exportDpr);
+      probe += ` [${axis} tryCss=${tryCss} boundsPhys=${bPhys} contentPhys=${cPhys}]`;
+      const err = Math.abs(cPhys - target);
+      if (cPhys >= presetVal && err <= bestErr) {
+        // Accept any value where contentPhys >= preset, prefer closest to target (=preset+margin)
+        if (err < bestErr || (err === bestErr && cPhys > bestContentPhys)) {
+          bestErr = err; bestCss = tryCss; bestContentPhys = cPhys;
+        }
+      } else if (bestContentPhys < presetVal && cPhys > bestContentPhys) {
+        // Fallback: if no valid overshoot found yet, keep the largest undershoot
+        bestErr = err; bestCss = tryCss; bestContentPhys = cPhys;
+      }
+    }
+    return bestCss;
+  };
+
+  cssWidth = snap(cssWidth, 'w', cssHeight);
+  let bounds = center(cssWidth, cssHeight);
+
+  // A frameless transparent window on Windows keeps a 1px DWM border (decoLeftCss = 1,
+  // sometimes also bottom). That border makes the captured whole-window source wider/taller
+  // than the content, so its aspect ratio can never exactly equal the preset and crop-and-scale
+  // pads black bars. Force the content rect to fill the whole window so bounds == content;
+  // retry a few times because a single setContentBounds can race with DWM. Once the decoration
+  // is gone, boundsPhys equals contentPhys and the source aspect ratio matches the preset.
+  for (let i = 0; i < 4; i++) {
+    mainWindow.setContentBounds({ x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height });
+    const cb = mainWindow.getContentBounds();
+    const b2 = mainWindow.getBounds();
+    const dl = cb.x - b2.x, dt = cb.y - b2.y;
+    const dr = (b2.x + b2.width) - (cb.x + cb.width);
+    const db = (b2.y + b2.height) - (cb.y + cb.height);
+    if (dl === 0 && dt === 0 && dr === 0 && db === 0) break;
+    bounds = b2;
+  }
+  bounds = mainWindow.getBounds();
+
+  // With the decoration removed, bounds == content, so snapping the height now targets the
+  // real content height: a CSS height of round(600/1.5)=400 yields boundsPhys==600 exactly.
+  cssHeight = snap(cssHeight, 'h', cssWidth);
+  bounds = center(cssWidth, cssHeight);
+
+  let boundsPhysW = Math.round(bounds.width * exportDpr);
+  let boundsPhysH = Math.round(bounds.height * exportDpr);
+
+  return {
+    exportDpr, cssWidth, cssHeight, bounds, boundsPhysW, boundsPhysH,
+  };
+}
+
 async function getMainWindowCaptureSource() {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return null;
@@ -3487,6 +3619,16 @@ app.on('before-quit', () => {
 // Settings Management IPC
 ipcMain.handle('window-set-native-theme', (event, themeSource) => {
   nativeTheme.themeSource = themeSource;
+});
+
+// Cache the main window's device pixel ratio so export window sizing can be
+// expressed in physical pixels (see resize-main-window / video-export-prepare-window).
+ipcMain.handle('report-device-pixel-ratio', (event, ratio) => {
+  if (!isTrustedMainWindowContents(event.sender)) return;
+  const dpr = Number(ratio);
+  if (Number.isFinite(dpr) && dpr > 0) {
+    mainWindow.__dpr = dpr;
+  }
 });
 
 ipcMain.handle('get-settings', () => {
@@ -4244,8 +4386,10 @@ ipcMain.handle('remote-control-send-command', (event, command) => {
       mainWindow.unmaximize();
     }
 
-    mainWindow.setContentSize(exportSize.width, exportSize.height, true);
-    mainWindow.center();
+    const fit = fitMainWindowBoundsToExportSize(exportSize);
+    if (!fit) {
+      return false;
+    }
     mainWindow.focus();
     return true;
   }
@@ -4323,10 +4467,16 @@ ipcMain.handle('video-export-prepare-window', (event, size) => {
     mainWindow.unmaximize();
   }
 
-  mainWindow.setContentSize(exportSize.width, exportSize.height, true);
-  mainWindow.center();
+  const fit = fitMainWindowBoundsToExportSize(exportSize);
+  if (!fit) {
+    return false;
+  }
+  const { exportDpr } = fit;
   mainWindow.focus();
-  return true;
+  return {
+    success: true,
+    dpr: exportDpr,
+  };
 });
 
 ipcMain.handle('video-export-restore-window', (event) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -148,6 +148,7 @@ contextBridge.exposeInMainWorld('electron', {
         return () => ipcRenderer.removeListener('remote-control-snapshot', listener);
     },
     chooseVideoExportPath: (defaultName, extension, displayName) => ipcRenderer.invoke('video-export-choose-path', defaultName, extension, displayName),
+    reportDevicePixelRatio: (ratio) => ipcRenderer.invoke('report-device-pixel-ratio', ratio),
     getMainWindowCaptureSource: () => ipcRenderer.invoke('video-export-get-main-window-source'),
     prepareVideoExportWindow: (size) => ipcRenderer.invoke('video-export-prepare-window', size),
     restoreVideoExportWindow: () => ipcRenderer.invoke('video-export-restore-window'),

--- a/src/hooks/useElectronPlaybackBridge.ts
+++ b/src/hooks/useElectronPlaybackBridge.ts
@@ -425,8 +425,19 @@ export const useElectronPlaybackBridge = ({
         publish({ includeLyrics: true });
         const intervalId = window.setInterval(() => publish(), 500);
 
-        const handleResize = () => publish();
+        let lastReportedDpr = window.devicePixelRatio || 1;
+        const handleResize = () => {
+            publish();
+            // Only report DPR when it actually changes (avoids unnecessary IPC round-trips).
+            const currentDpr = window.devicePixelRatio || 1;
+            if (currentDpr !== lastReportedDpr) {
+                lastReportedDpr = currentDpr;
+                window.electron?.reportDevicePixelRatio(currentDpr);
+            }
+        };
         window.addEventListener('resize', handleResize);
+        // Report once on mount in case the window is never resized before exporting.
+        window.electron?.reportDevicePixelRatio(lastReportedDpr);
 
         return () => {
             window.clearInterval(intervalId);

--- a/src/hooks/useElectronVideoExportController.ts
+++ b/src/hooks/useElectronVideoExportController.ts
@@ -8,6 +8,7 @@ import type { VideoExportPreset, VideoExportState } from '../types/videoExport';
 import { idleVideoExportState } from '../types/videoExport';
 import {
     buildDefaultVideoExportFileName,
+    createCroppedVideoStream,
     getAudioElementCaptureStream,
     getMainWindowVideoCaptureStream,
     getVideoExportRecorderOptions,
@@ -98,6 +99,7 @@ export const useElectronVideoExportController = ({
         let progressIntervalId: number | null = null;
         let endedListener: (() => void) | null = null;
         let removeCursorGuard: (() => void) | null = null;
+        let canvasCropCleanup: (() => void) | null = null;
         const wasPaused = audioElement.paused;
         const previousLoop = audioElement.loop;
         const previousTime = audioElement.currentTime;
@@ -151,11 +153,20 @@ export const useElectronVideoExportController = ({
             }
 
             const prepared = await electron.prepareVideoExportWindow({ width: preset.width, height: preset.height });
-            if (!prepared) {
+            if (prepared === false || !prepared.success) {
                 throw new Error(t('export.windowResizeFailed'));
             }
             await wait(300);
             videoStream = await getMainWindowVideoCaptureStream(preset);
+
+            // Canvas post-processing: pure integer crop to exact preset resolution.
+            // The snap strategy in main.cjs ensures contentPhys >= preset + margin,
+            // so the captured frame is naturally larger than the target — we simply
+            // extract a preset-sized region with symmetric pixel-perfect cropping.
+            const cropped = createCroppedVideoStream(videoStream, preset);
+            videoStream = cropped.stream;
+            canvasCropCleanup = cropped.cleanup;
+
             audioStream = getAudioElementCaptureStream(audioElement);
             combinedStream = new MediaStream([
                 ...videoStream.getVideoTracks(),
@@ -271,6 +282,7 @@ export const useElectronVideoExportController = ({
             }
             setIsPlayerChromeHidden(false);
             removeCursorGuard?.();
+            canvasCropCleanup?.();
             void electron.restoreVideoExportWindow();
             runningRef.current = false;
             cancelRequestedRef.current = false;

--- a/src/services/electronVideoExport.ts
+++ b/src/services/electronVideoExport.ts
@@ -143,6 +143,10 @@ export const createCroppedVideoStream = (
             cancelAnimationFrame(animFrameId);
             animFrameId = null;
         }
+        // Stop the original source tracks (e.g. desktop/window capture) so they
+        // aren't left active after export. stopMediaStream on the cropped canvas
+        // stream cannot reach these tracks — they only live on sourceStream.
+        stopMediaStream(sourceStream);
         video.pause();
         video.srcObject = null;
         video.remove();

--- a/src/services/electronVideoExport.ts
+++ b/src/services/electronVideoExport.ts
@@ -7,6 +7,151 @@ const EXPORT_FRAME_RATE = 60;
 const EXPORT_AUDIO_BITS_PER_SECOND = 320_000;
 const VIDEO_EXPORT_FILE_EXTENSIONS = ['mp4', 'webm'] as const;
 
+/**
+ * Creates a cropped/scaled video stream from a capture source using an offscreen Canvas.
+ *
+ * This solves the black-bar problem caused by Windows DWM decoration on frameless windows:
+ * - The desktopCapturer source resolution (boundsPhys) rarely matches the preset exactly
+ *   due to 1px DWM borders and half-pixel DPI scaling (e.g. dpr=1.5)
+ * - Forcing the output via minWidth/maxWidth constraints causes Chromium to letterbox,
+ *   adding black bars when source aspect ≠ output aspect
+ *
+ * Instead, we capture at the native source resolution, then use Canvas 2D to crop/scale
+ * each frame to the exact preset size using "cover" mode (content fills the output,
+ * edges are clipped if needed — no black bars).
+ */
+export const createCroppedVideoStream = (
+    sourceStream: MediaStream,
+    preset: VideoExportPreset,
+): { stream: MediaStream; cleanup: () => void } => {
+    const canvas = document.createElement('canvas');
+    canvas.width = preset.width;
+    canvas.height = preset.height;
+    const ctx = canvas.getContext('2d', { alpha: false });
+
+    if (!ctx) {
+        throw new Error('[VideoExport] Failed to create 2D canvas context for video cropping');
+    }
+
+    // High-quality interpolation: used only in the abnormal cover-fallback path
+    // (pure-crop path has scale=1.0, no interpolation needed).
+    ctx.imageSmoothingQuality = 'high';
+
+    const videoTrack = sourceStream.getVideoTracks()[0];
+    if (!videoTrack) {
+        throw new Error('[VideoExport] No video track in source stream for cropping');
+    }
+
+    // Create a video element to decode frames from the source track.
+    // We must use video.videoWidth/videoHeight (available after loadedmetadata)
+    // rather than track.getSettings() because they reflect the actual decoded
+    // frame dimensions, which may differ from the track's nominal settings.
+    const video = document.createElement('video');
+    video.autoplay = true;
+    video.muted = true;
+    video.playsInline = true;
+    video.srcObject = new MediaStream([videoTrack]);
+
+    let animFrameId: number | null = null;
+    let isRunning = true;
+
+    // Crop geometry — computed after metadata loads when videoWidth/videoHeight are available
+    let drawW = 0;
+    let drawH = 0;
+    let offsetX = 0;
+    let offsetY = 0;
+    let geometryReady = false;
+
+    // Start rendering after video metadata loads and we can read real frame size
+    video.onloadedmetadata = () => {
+        // Use actual decoded frame dimensions, NOT track settings
+        const srcW = video.videoWidth || preset.width;
+        const srcH = video.videoHeight || preset.height;
+
+        // Pure crop mode: the snap strategy in main.cjs now ensures contentPhys >= preset + margin,
+        // so the captured frame should be larger than the target on at least one dimension.
+        // We simply extract a preset-sized region from the center of the source frame,
+        // with symmetric integer cropping (no scaling, no resampling, pixel-perfect).
+        if (srcW >= preset.width && srcH >= preset.height) {
+            // Pure crop: both dimensions have enough pixels
+            const cropW = srcW - preset.width;
+            const cropH = srcH - preset.height;
+            offsetX = Math.floor(cropW / 2);   // left/top gets fewer pixels on odd
+            offsetY = Math.floor(cropH / 2);
+            drawW = preset.width;               // exact target size
+            drawH = preset.height;
+            console.log(
+                `[VideoExport] Canvas crop: source=${srcW}x${srcH} -> target=${preset.width}x${preset.height} ` +
+                `mode=pure-crop offset=(${offsetX},${offsetY}) [L${offsetX}T${offsetY}R${cropW - offsetX}B${cropH - offsetY}]`,
+            );
+        } else {
+            // Fallback: source is smaller than target on at least one dimension (abnormal).
+            // This should never happen with the snap-overshoot strategy in main.cjs.
+            // Use cover-fit with minimal upscale as last resort — mild distortion is acceptable
+            // here because this path indicates a configuration or platform bug, not normal operation.
+            console.warn(
+                `[VideoExport] Canvas crop: source (${srcW}x${srcH}) < target (${preset.width}x${preset.height}), falling back to cover mode`,
+            );
+            const scaleX = preset.width / srcW;
+            const scaleY = preset.height / srcH;
+            const scale = Math.max(scaleX, scaleY);
+            const srcDrawW = Math.round(preset.width / scale);
+            const srcDrawH = Math.round(preset.height / scale);
+            let sx = Math.floor((srcW - srcDrawW) / 2);
+            let sy = Math.floor((srcH - srcDrawH) / 2);
+            sx = Math.max(0, Math.min(sx, srcW - 1));
+            sy = Math.max(0, Math.min(sy, srcH - 1));
+            offsetX = sx;
+            offsetY = sy;
+            drawW = Math.min(srcDrawW, srcW - sx);  // Clamp to avoid out-of-bounds read (may cause slight stretch)
+            drawH = Math.min(srcDrawH, srcH - sy);
+            console.log(
+                `[VideoExport] Canvas crop: source=${srcW}x${srcH} -> target=${preset.width}x${preset.height} ` +
+                `mode=cover-fallback scale=${scale.toFixed(4)} srcRegion=(${offsetX},${offsetY},${drawW}x${drawH})`,
+            );
+        }
+
+        geometryReady = true;
+        renderFrame();
+    };
+
+    // Render loop: draw each video frame onto the canvas with cover cropping
+    const renderFrame = () => {
+        if (!isRunning) return;
+        if (geometryReady && video.readyState >= video.HAVE_CURRENT_DATA) {
+            // Clear and draw with cover fit using pre-computed geometry.
+            // Use 9-parameter drawImage to sample a source region (sx,sy,sW,sH)
+            // and stretch it to fill the entire canvas (0,0,presetW,presetH).
+            ctx!.fillStyle = '#000';
+            ctx!.fillRect(0, 0, preset.width, preset.height);
+            ctx!.drawImage(video, offsetX, offsetY, drawW, drawH, 0, 0, preset.width, preset.height);
+        }
+        animFrameId = requestAnimationFrame(renderFrame);
+    };
+
+    // Create output stream from the canvas at the target frame rate
+    const canvasStream = canvas.captureStream(EXPORT_FRAME_RATE);
+
+    // Copy all audio tracks from source (passthrough)
+    sourceStream.getAudioTracks().forEach(track => {
+        canvasStream.addTrack(track);
+    });
+
+    const cleanup = () => {
+        isRunning = false;
+        if (animFrameId !== null) {
+            cancelAnimationFrame(animFrameId);
+            animFrameId = null;
+        }
+        video.pause();
+        video.srcObject = null;
+        video.remove();
+        canvas.remove();
+    };
+
+    return { stream: canvasStream, cleanup };
+};
+
 export type VideoExportFileExtension = typeof VIDEO_EXPORT_FILE_EXTENSIONS[number];
 
 export type VideoExportFormat = {
@@ -119,21 +264,33 @@ export const getMainWindowVideoCaptureStream = async (preset: VideoExportPreset)
         throw new Error('Could not find the main player window capture source.');
     }
 
-    return navigator.mediaDevices.getUserMedia({
+    // Capture at the native source resolution WITHOUT forcing minWidth/maxWidth constraints.
+    // Forcing the output size causes Chromium to letterbox when the native source size
+    // (which includes Windows DWM decoration on frameless windows) doesn't match the
+    // preset exactly — resulting in black bars. Instead, we capture the raw source and
+    // use Canvas post-processing (createCroppedVideoStream) to crop/scale to the exact
+    // preset size with cover mode (no black bars, edges clipped if needed).
+    const stream = await navigator.mediaDevices.getUserMedia({
         audio: false,
         video: {
-            // Chromium's legacy desktop source constraints cannot be mixed with
-            // standard cursor/displaySurface constraints; cursor hiding is handled
-            // by installVideoExportCursorGuard while recording.
             mandatory: {
                 chromeMediaSource: 'desktop',
                 chromeMediaSourceId: source.id,
-                minWidth: preset.width,
-                maxWidth: preset.width,
-                minHeight: preset.height,
-                maxHeight: preset.height,
                 maxFrameRate: EXPORT_FRAME_RATE,
             },
         } as unknown as MediaTrackConstraints,
     });
+
+    // Log the actual native capture resolution for diagnostics.
+    const videoTrack = stream.getVideoTracks()[0];
+    if (videoTrack) {
+        const settings = videoTrack.getSettings();
+        console.log(
+            `[VideoExport] capture native stream -> ${settings.width}x${settings.height} ` +
+            `(preset=${preset.width}x${preset.height}) ` +
+            `${settings.width === preset.width && settings.height === preset.height ? 'NATIVE==PRESET' : 'NATIVE!=PRESET->canvas-crop'}`,
+        );
+    }
+
+    return stream;
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -583,8 +583,10 @@ declare global {
         extension?: 'mp4' | 'webm',
         displayName?: string,
       ) => Promise<ElectronSaveDialogResult>;
+      reportDevicePixelRatio: (ratio: number) => Promise<void>;
       getMainWindowCaptureSource: () => Promise<ElectronWindowCaptureSource | null>;
-      prepareVideoExportWindow: (size: { width: number; height: number }) => Promise<boolean>;
+      // Returns `false` when the resize could not be prepared, otherwise the resolved DPR.
+      prepareVideoExportWindow: (size: { width: number; height: number }) => Promise<false | { success: boolean; dpr: number }>;
       restoreVideoExportWindow: () => Promise<boolean>;
       writeVideoExportFile: (filePath: string, data: ArrayBuffer) => Promise<boolean>;
       getStageStatus: () => Promise<StageStatus>;


### PR DESCRIPTION
fix #280 

原录制方式在高分屏下，实际上在超采样录制；并且录制结果存在黑边。

改善的方式对系统缩放进行了逆运算，录制窗口尺寸会比录制目标略大，通过裁切解决黑边问题（除非窗口尺寸受限，否则屏幕渲染到录制结果点对点，无缩放）。

附一个我用来检测录制结果分辨率和黑边大小的脚本，可以下载py脚本并保存如下代码为bat，拖拽多个视频文件到bat上来使用
```
@echo off
python "%~dp0oneframe.py" --ask %*
```
[oneframe.py](https://github.com/user-attachments/files/31379283/oneframe.py)
