### PR TITLE
fix: 修复莫奈/monet歌词过长情况下的文字重叠问题

### DIFF
--- a/skills/reuse-project-utilities/SKILL.md
+++ b/skills/reuse-project-utilities/SKILL.md
@@ -66,6 +66,47 @@ const width = layout.lines[0]?.width ?? fallbackWidth;
 
 不要手写 `text.length * fontSize` 作为主测量逻辑；只能作为 fallback。
 
+#### 测量必须和真实渲染结构一致
+
+`prepareWithSegments(fullText, fontSpec)` 把整行当成一个可任意断开的字符串。只有当 DOM 里这行文本
+也是一个普通的 inline 文本流时，这个假设才成立。
+
+如果渲染时把每个词/token 包成了 `display: inline-block`（逐字扫光、per-word 上色、chip、mention 都会这么做），
+那它就是**原子行内盒，内部不允许断行**，浏览器只能在 token 之间断。中日文尤其明显：词间没有空格，
+pretext 会在任意字之间断，浏览器只能在 token 边界断，实测行数可以差 1~2 行。行数算少了，
+预留高度就不够，多出来的行会从 padding 里漏出去压到下一个区块（Monet 歌词压到翻译行就是这么来的）。
+
+这种情况用 rich-inline helper，把原子 token 标成 `break: 'never'`：
+
+```ts
+import { measureRichInlineStats, prepareRichInline, type RichInlineItem } from '@chenglou/pretext/rich-inline';
+
+const items: RichInlineItem[] = tokens.map(token => ({
+    text: token.text,
+    font: fontSpec,
+    break: token.timed ? 'never' : 'normal',   // 'never' == inline-block 原子盒
+}));
+const { lineCount } = measureRichInlineStats(prepareRichInline(items), maxWidthPx);
+```
+
+实测（Chromium，对照真实 DOM 行数）：token 都放得进列宽时，`break: 'never'` 154 组用例**零误差**，
+而按整串测量错 14 组。参考实现见 `measureLyricLineCount`（`src/components/visualizer/monet/monetLyricsModel.ts`）。
+
+其它容易踩的对齐点：
+
+- **`whiteSpace`**：`prepare()` / `prepareWithSegments()` 默认按 `white-space: normal` 处理。DOM 上写了
+  `whitespace-pre-wrap` 就必须传 `{ whiteSpace: 'pre-wrap' }`，否则连续空格被折叠，行数算少。
+- **`letterSpacing` / `wordBreak`**：CSS 上有 `letter-spacing`、`word-break: keep-all` 时，同样要作为 options 传进去。
+- **零宽字符不是断行控制手段**：U+2060 WORD JOINER、U+FEFF 都不会阻止 pretext 断行（宽度为 0，断点照旧），
+  别指望靠插入零宽字符来表达"不可断"。要原子性就用 rich-inline 的 `break: 'never'`。
+- **超宽 token 仍不精确**：token 自然宽度超过列宽时，Blink 对 `inline-block` 的 shrink-to-fit 行为
+  （`overflow-wrap: break-word` 不参与 min-content 计算，结果是溢出而不是内部换行）rich-inline 没有建模，
+  实测仍有偏差。这种极端情形不要依赖测量值兜底，改用内容自撑高度。
+- **`system-ui` 在 macOS 上不可靠**：pretext README 明确说明 `layout()` 精度对 `system-ui` 不保证，字体栈里
+  优先落到具名字体。
+- **单测要 mock 子路径**：`vi.mock('@chenglou/pretext')` 不会覆盖 `@chenglou/pretext/rich-inline`，
+  两个都要 mock，否则 node 环境下会抛 `Text measurement requires OffscreenCanvas or a DOM canvas context.`。
+
 ### Visualizer Runtime
 
 visualizer 当前行、上一行、下一行、预热窗口已有共享入口：
@@ -239,6 +280,7 @@ const { t } = useTranslation();
 - 是否新增固定颜色却没有从 `Theme` / `DualTheme` 动态派生并检查明暗两套表现？
 - 是否硬编码歌词或字幕字重，而没有使用 `resolveThemeFontWeight` 和模式 fallback？
 - DOM、Canvas、pretext、光栅化的最终字重以及布局缓存键是否一致？
+- pretext 测量的文本结构是否和实际渲染结构一致？渲染成 `inline-block` token 时要用 rich-inline 的 `break: 'never'`，DOM 上是 `whitespace-pre-wrap` 时要传 `{ whiteSpace: 'pre-wrap' }`。
 - 是否创建了相似 helper，却没有搜索已有实现或测试？
 
 ## Validation

--- a/src/components/visualizer/monet/MonetLyricsRail.tsx
+++ b/src/components/visualizer/monet/MonetLyricsRail.tsx
@@ -79,6 +79,14 @@ const MONET_RAIL_WIDTH_FALLBACK_PX = 680;
 const MONET_RAIL_HEIGHT_FALLBACK_PX = 340;
 const MONET_ACTIVE_GAP_PX = 18;
 const MONET_INACTIVE_GAP_PX = 14;
+// Ratios reproduce the fixed gaps above at the default 36.5px lyric font, so nothing changes at
+// normal sizes; past that the gaps grow with the text instead of collapsing into it.
+// The height cap must clear the active block at large font scales, where a narrow column pushes
+// a normal lyric past four rows. Seven rows stays below the base cap at default sizes, so this
+// only ever raises the ceiling for oversized text on a tall display.
+const MONET_RAIL_MIN_ROWS = 7;
+const MONET_ACTIVE_GAP_RATIO = 0.49;
+const MONET_INACTIVE_GAP_RATIO = 0.38;
 const MONET_GLOW_RISE_DURATION_SCALE = 1.18;
 const MONET_GLOW_PASS_TAIL_SECONDS = 1.05;
 const MONET_SCROLL_IDLE_RESET_MS = 1800;
@@ -144,10 +152,14 @@ const resolveLineTone = (
     };
 };
 
-const resolveLineGap = (previous: PositionedMonetLineEntry, next: PositionedMonetLineEntry): number => (
+const resolveLineGap = (
+    previous: PositionedMonetLineEntry,
+    next: PositionedMonetLineEntry,
+    lyricFontPx: number,
+): number => (
     previous.status === 'active' || next.status === 'active'
-        ? MONET_ACTIVE_GAP_PX
-        : MONET_INACTIVE_GAP_PX
+        ? Math.max(MONET_ACTIVE_GAP_PX, lyricFontPx * MONET_ACTIVE_GAP_RATIO)
+        : Math.max(MONET_INACTIVE_GAP_PX, lyricFontPx * MONET_INACTIVE_GAP_RATIO)
 );
 
 const resolveRailLineStatus = (lineIndex: number, activeLineIndex: number): MonetLineStatus => {
@@ -352,13 +364,13 @@ const buildPositionedEntries = (
     for (let index = anchorIndex + 1; index < measuredEntries.length; index += 1) {
         const previous = measuredEntries[index - 1];
         const current = measuredEntries[index];
-        current.y = previous.y + previous.scaledHeight + resolveLineGap(previous, current);
+        current.y = previous.y + previous.scaledHeight + resolveLineGap(previous, current, lyricFontPx);
     }
 
     for (let index = anchorIndex - 1; index >= 0; index -= 1) {
         const current = measuredEntries[index];
         const next = measuredEntries[index + 1];
-        current.y = next.y - current.scaledHeight - resolveLineGap(current, next);
+        current.y = next.y - current.scaledHeight - resolveLineGap(current, next, lyricFontPx);
     }
 
     return measuredEntries;
@@ -369,6 +381,25 @@ const getLineMask = (isClipped: boolean, fadePx: number) => (
         ? `linear-gradient(180deg, black 0%, black calc(100% - ${fadePx}px), transparent 100%)`
         : undefined
 );
+
+/**
+ * Cuts a truncated context line at its last visible text row rather than at the box edge.
+ * `overflow: hidden` clips at the padding box, and that padding carries `vGlowBufferPx`
+ * (1.2x the lyric font) of glow headroom — at large font scales that is more than a whole line,
+ * so the clipped row stays visible and lands on top of the neighbouring lyric.
+ */
+const getClippedTextMask = (
+    isClipped: boolean,
+    contentBottomPx: number,
+    fadePx: number,
+) => {
+    if (!isClipped) {
+        return undefined;
+    }
+
+    const solidEndPx = Math.max(contentBottomPx - fadePx, 0);
+    return `linear-gradient(180deg, black 0px, black ${solidEndPx}px, transparent ${contentBottomPx}px)`;
+};
 
 /** Softens the right edge so a token wider than the column fades out instead of being sliced mid-glyph. */
 const getEdgeFadeMask = (isOverflowing: boolean, fadePx: number) => (
@@ -667,7 +698,11 @@ const MonetRailLine: React.FC<{
     const isActiveLine = entry.status === 'active';
     const textMask = isActiveLine
         ? undefined
-        : getLineMask(entry.layout.isTextClipped, Math.max(lyricFontPx * 0.55, 12));
+        : getClippedTextMask(
+            entry.layout.isTextClipped,
+            vGlowBufferPx + entry.layout.textPaddingTopPx + entry.layout.textContentHeightPx,
+            Math.max(lyricFontPx * 0.55, 12),
+        );
     const textEdgeMask = getEdgeFadeMask(entry.layout.isTextOverflowingWidth, Math.max(lyricFontPx * 0.9, 24));
     const textMaskStyle = composeLineMasks(textMask, textEdgeMask);
     const translationMask = getLineMask(entry.layout.isTranslationClipped, Math.max(translationFontPx * 0.65, 10));
@@ -849,7 +884,10 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
     const vGlowBufferPx = Math.round(lyricFontPx * 1.2);
     // Grows with the same factor as the font, so the column-to-font ratio — and the wrapping — holds.
     const railMaxWidthPx = Math.round(MONET_RAIL_BASE_MAX_WIDTH_PX * layoutScale);
-    const railMaxHeightPx = Math.round(MONET_RAIL_BASE_MAX_HEIGHT_PX * layoutScale);
+    const railMaxHeightPx = Math.round(Math.max(
+        MONET_RAIL_BASE_MAX_HEIGHT_PX * layoutScale,
+        lyricFontPx * 1.18 * MONET_RAIL_MIN_ROWS,
+    ));
     const canSeek = Boolean(onLyricLineSeek) && !seekDisabled;
     const lyricFontWeight = resolveThemeFontWeight(theme, 600);
     const translationFontWeight = resolveThemeFontWeight(subtitleTheme ?? theme, 500);

--- a/src/components/visualizer/monet/MonetLyricsRail.tsx
+++ b/src/components/visualizer/monet/MonetLyricsRail.tsx
@@ -13,6 +13,8 @@ import {
     type WordColorMatcher,
 } from '../wordColoring';
 import {
+    MONET_RAIL_BASE_MAX_HEIGHT_PX,
+    MONET_RAIL_BASE_MAX_WIDTH_PX,
     buildMonetDisplayTokens,
     measureMonetGraphemeOffsets,
     measureMonetLineLayout,
@@ -46,6 +48,8 @@ interface MonetLyricsRailProps {
     audioBands?: AudioBands;
     onLyricLineSeek?: (lyricTimeSec: number) => void;
     seekDisabled?: boolean;
+    /** Shared large-screen factor. Owned by VisualizerMonet so the column and the font scale together. */
+    layoutScale?: number;
 }
 
 interface MonetRailSize {
@@ -366,6 +370,33 @@ const getLineMask = (isClipped: boolean, fadePx: number) => (
         : undefined
 );
 
+/** Softens the right edge so a token wider than the column fades out instead of being sliced mid-glyph. */
+const getEdgeFadeMask = (isOverflowing: boolean, fadePx: number) => (
+    isOverflowing
+        ? `linear-gradient(90deg, black 0%, black calc(100% - ${fadePx}px), transparent 100%)`
+        : undefined
+);
+
+/** Intersects the vertical clip fade with the horizontal edge fade, so a line can carry both. */
+const composeLineMasks = (...masks: (string | undefined)[]) => {
+    const layers = masks.filter((mask): mask is string => Boolean(mask));
+    if (layers.length === 0) {
+        return undefined;
+    }
+
+    return {
+        WebkitMaskImage: layers.join(', '),
+        maskImage: layers.join(', '),
+        WebkitMaskRepeat: 'no-repeat',
+        maskRepeat: 'no-repeat',
+        WebkitMaskSize: '100% 100%',
+        maskSize: '100% 100%',
+        ...(layers.length > 1
+            ? { WebkitMaskComposite: 'source-in', maskComposite: 'intersect' }
+            : {}),
+    } as const;
+};
+
 const MonetTimedTokenSpan: React.FC<{
     entry: PositionedMonetLineEntry;
     currentTime: MotionValue<number>;
@@ -637,6 +668,8 @@ const MonetRailLine: React.FC<{
     const textMask = isActiveLine
         ? undefined
         : getLineMask(entry.layout.isTextClipped, Math.max(lyricFontPx * 0.55, 12));
+    const textEdgeMask = getEdgeFadeMask(entry.layout.isTextOverflowingWidth, Math.max(lyricFontPx * 0.9, 24));
+    const textMaskStyle = composeLineMasks(textMask, textEdgeMask);
     const translationMask = getLineMask(entry.layout.isTranslationClipped, Math.max(translationFontPx * 0.65, 10));
     const handleSeek = (event: React.MouseEvent | React.KeyboardEvent) => {
         if (!canSeek) {
@@ -726,12 +759,7 @@ const MonetRailLine: React.FC<{
                     fontWeight: entry.tone.fontWeight,
                     lineHeight: `${entry.layout.lineHeightPx}px`,
                     letterSpacing: 0,
-                    WebkitMaskImage: textMask,
-                    maskImage: textMask,
-                    WebkitMaskRepeat: 'no-repeat',
-                    maskRepeat: 'no-repeat',
-                    WebkitMaskSize: '100% 100%',
-                    maskSize: '100% 100%',
+                    ...textMaskStyle,
                     textShadow: entry.status === 'active'
                         ? `0 14px 34px ${colorWithAlpha(theme.backgroundColor, 0.22)}`
                         : 'none',
@@ -805,6 +833,7 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
     audioBands,
     onLyricLineSeek,
     seekDisabled = false,
+    layoutScale = 1,
 }) => {
     const railRef = useRef<HTMLDivElement | null>(null);
     const layoutCacheRef = useRef<MonetLayoutCache>(new Map());
@@ -818,6 +847,9 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
     const railSize = useMonetRailSize(railRef);
     const glowBufferPx = Math.round(lyricFontPx * 1.2);
     const vGlowBufferPx = Math.round(lyricFontPx * 1.2);
+    // Grows with the same factor as the font, so the column-to-font ratio — and the wrapping — holds.
+    const railMaxWidthPx = Math.round(MONET_RAIL_BASE_MAX_WIDTH_PX * layoutScale);
+    const railMaxHeightPx = Math.round(MONET_RAIL_BASE_MAX_HEIGHT_PX * layoutScale);
     const canSeek = Boolean(onLyricLineSeek) && !seekDisabled;
     const lyricFontWeight = resolveThemeFontWeight(theme, 600);
     const translationFontWeight = resolveThemeFontWeight(subtitleTheme ?? theme, 500);
@@ -1001,8 +1033,10 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
     return (
         <div
             ref={railRef}
-            className="relative h-[clamp(280px,52vh,520px)] max-w-[720px] select-none overflow-hidden"
+            className="relative select-none overflow-hidden"
             style={{
+                height: `clamp(280px, 52vh, ${railMaxHeightPx}px)`,
+                maxWidth: `${railMaxWidthPx}px`,
                 marginLeft: `-${glowBufferPx}px`,
                 marginRight: `-${glowBufferPx}px`,
                 paddingLeft: `${glowBufferPx}px`,

--- a/src/components/visualizer/monet/MonetLyricsRail.tsx
+++ b/src/components/visualizer/monet/MonetLyricsRail.tsx
@@ -436,12 +436,13 @@ const MonetTimedTokenSpan: React.FC<{
     accentColor: string;
     fontPx: number;
     fontStack: string;
+    fontsEpoch: number;
     wordColorMatchers: WordColorMatcher[];
     isChorus?: boolean;
     chorusAccentColor?: string;
     audioPower?: MotionValue<number>;
     renderStaticPassed?: boolean;
-}> = ({ entry, currentTime, accentColor, fontPx, fontStack, wordColorMatchers, isChorus, chorusAccentColor, audioPower, renderStaticPassed = false }) => {
+}> = ({ entry, currentTime, accentColor, fontPx, fontStack, fontsEpoch, wordColorMatchers, isChorus, chorusAccentColor, audioPower, renderStaticPassed = false }) => {
     const lineRenderEndTime = useMemo(() => getLineRenderEndTime(entry.line), [entry.line]);
     const tokens = useMemo(() => buildMonetDisplayTokens(entry.line), [entry.line]);
     const wordColorRanges = useMemo(
@@ -489,6 +490,7 @@ const MonetTimedTokenSpan: React.FC<{
                         baseColor={entry.tone.baseColor}
                         fontPx={fontPx}
                         fontSpec={fontSpec}
+                        fontsEpoch={fontsEpoch}
                         isChorus={isChorus}
                         audioPower={audioPower}
                     />
@@ -514,6 +516,8 @@ const MonetWordSweep: React.FC<{
     baseColor: string;
     fontPx: number;
     fontSpec: string;
+    /** Bumped when web fonts load; measured offsets are stale until then. */
+    fontsEpoch: number;
     isChorus?: boolean;
     audioPower?: MotionValue<number>;
 }> = ({
@@ -528,12 +532,12 @@ const MonetWordSweep: React.FC<{
     baseColor,
     fontPx,
     fontSpec,
+    fontsEpoch,
     isChorus,
     audioPower,
 }) => {
         const isLineActive = lineStatus === 'active';
         const canRenderGlow = lineStatus === 'active' || lineStatus === 'passed';
-        const fontsEpoch = useFontsEpoch();
         const graphemeOffsets = useMemo(
             () => measureMonetGraphemeOffsets(text, fontPx, fontSpec),
             // eslint-disable-next-line react-hooks/exhaustive-deps -- fontsEpoch re-measures once the real face loads
@@ -701,6 +705,7 @@ const MonetRailLine: React.FC<{
     translationFontWeight: number;
     glowBufferPx: number;
     vGlowBufferPx: number;
+    fontsEpoch: number;
     wordColorMatchers: WordColorMatcher[];
     showSubtitleTranslation: boolean;
     audioPower?: MotionValue<number>;
@@ -708,7 +713,7 @@ const MonetRailLine: React.FC<{
     canSeek?: boolean;
     disableEntryMotion?: boolean;
     renderStaticPassed?: boolean;
-}> = ({ entry, currentTime, theme, lyricFontPx, translationFontPx, fontStack, translationFontStack, translationFontWeight, glowBufferPx, vGlowBufferPx, wordColorMatchers, showSubtitleTranslation, audioPower, onLineSeek, canSeek = false, disableEntryMotion = false, renderStaticPassed = false }) => {
+}> = ({ entry, currentTime, theme, lyricFontPx, translationFontPx, fontStack, translationFontStack, translationFontWeight, glowBufferPx, vGlowBufferPx, fontsEpoch, wordColorMatchers, showSubtitleTranslation, audioPower, onLineSeek, canSeek = false, disableEntryMotion = false, renderStaticPassed = false }) => {
     const initialOffset = entry.offset >= 0 ? 34 : -34;
     const exitOffset = entry.status === 'passed' || entry.offset < 0 ? -38 : 38;
     // The active lyric must never be truncated, so its box is sized by its own wrapped
@@ -825,6 +830,7 @@ const MonetRailLine: React.FC<{
                     accentColor={colorWithAlpha(theme.primaryColor, 0.98)}
                     fontPx={lyricFontPx}
                     fontStack={fontStack}
+                    fontsEpoch={fontsEpoch}
                     wordColorMatchers={wordColorMatchers}
                     isChorus={entry.line.isChorus}
                     chorusAccentColor={theme.accentColor}
@@ -1133,6 +1139,7 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
                             translationFontWeight={translationFontWeight}
                             glowBufferPx={glowBufferPx}
                             vGlowBufferPx={vGlowBufferPx}
+                            fontsEpoch={fontsEpoch}
                             wordColorMatchers={wordColorMatchers}
                             showSubtitleTranslation={showSubtitleTranslation}
                             audioPower={audioPower}

--- a/src/components/visualizer/monet/MonetLyricsRail.tsx
+++ b/src/components/visualizer/monet/MonetLyricsRail.tsx
@@ -634,6 +634,13 @@ const MonetWordSweep: React.FC<{
             return `0 0 ${radiusOne}px ${glowColor}, 0 0 ${radiusTwo}px ${glowColor}`;
         }) as unknown as MotionValue<string>;
 
+        // Glyphs with deep descenders (g, j, p, y, and many CJK forms) sit below the line box
+        // whenever the font's em box is taller than `line-height`, which drives half-leading
+        // negative. `background-clip: text` paints no background outside the fill box and the mask
+        // clips at the overlay's border box, so the sweep used to stop mid-glyph — more visibly the
+        // larger the font. Grow both boxes, then pull the text back so its position is unchanged.
+        const sweepOverflowPx = Math.round(fontPx * 0.5);
+
         return (
             <span className="relative inline-block whitespace-pre-wrap break-words">
                 <motion.span style={{ color: resolvedBaseColor, textShadow: glowShadow }}>
@@ -642,8 +649,13 @@ const MonetWordSweep: React.FC<{
                 {isLineActive ? (
                     <motion.span
                         aria-hidden
-                        className="pointer-events-none absolute inset-0 block whitespace-pre-wrap break-words"
+                        className="pointer-events-none absolute left-0 right-0 block whitespace-pre-wrap break-words"
                         style={{
+                            top: -sweepOverflowPx,
+                            bottom: -sweepOverflowPx,
+                            paddingTop: sweepOverflowPx,
+                            paddingBottom: sweepOverflowPx,
+                            boxSizing: 'border-box',
                             WebkitMaskImage: maskImage,
                             maskImage,
                             WebkitMaskSize: '100% 100%',
@@ -656,6 +668,9 @@ const MonetWordSweep: React.FC<{
                         <motion.span
                             className="block whitespace-pre-wrap break-words"
                             style={{
+                                marginTop: -sweepOverflowPx,
+                                paddingTop: sweepOverflowPx,
+                                paddingBottom: sweepOverflowPx,
                                 color: 'transparent',
                                 WebkitTextFillColor: 'transparent',
                                 backgroundImage: fillGradient,

--- a/src/components/visualizer/monet/MonetLyricsRail.tsx
+++ b/src/components/visualizer/monet/MonetLyricsRail.tsx
@@ -630,7 +630,13 @@ const MonetRailLine: React.FC<{
 }> = ({ entry, currentTime, theme, lyricFontPx, translationFontPx, fontStack, translationFontStack, translationFontWeight, glowBufferPx, vGlowBufferPx, wordColorMatchers, showSubtitleTranslation, audioPower, onLineSeek, canSeek = false, disableEntryMotion = false, renderStaticPassed = false }) => {
     const initialOffset = entry.offset >= 0 ? 34 : -34;
     const exitOffset = entry.status === 'passed' || entry.offset < 0 ? -38 : 38;
-    const textMask = getLineMask(entry.layout.isTextClipped, Math.max(lyricFontPx * 0.55, 12));
+    // The active lyric must never be truncated, so its box is sized by its own wrapped
+    // content instead of the pre-measured height, and it carries no truncation fade.
+    // Context lines keep the fixed two-line box that keeps the rail compact.
+    const isActiveLine = entry.status === 'active';
+    const textMask = isActiveLine
+        ? undefined
+        : getLineMask(entry.layout.isTextClipped, Math.max(lyricFontPx * 0.55, 12));
     const translationMask = getLineMask(entry.layout.isTranslationClipped, Math.max(translationFontPx * 0.65, 10));
     const handleSeek = (event: React.MouseEvent | React.KeyboardEvent) => {
         if (!canSeek) {
@@ -711,7 +717,9 @@ const MonetRailLine: React.FC<{
                     marginBottom: `-${vGlowBufferPx}px`,
                     paddingTop: `${entry.layout.textPaddingTopPx + vGlowBufferPx}px`,
                     paddingBottom: `${entry.layout.textPaddingBottomPx + vGlowBufferPx}px`,
-                    height: `${entry.layout.textHeightPx + vGlowBufferPx * 2}px`,
+                    height: isActiveLine
+                        ? undefined
+                        : `${entry.layout.textHeightPx + vGlowBufferPx * 2}px`,
                     boxSizing: 'border-box',
                     fontFamily: fontStack,
                     fontSize: lyricFontPx,
@@ -993,7 +1001,7 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
     return (
         <div
             ref={railRef}
-            className="relative h-[clamp(260px,42vh,400px)] max-w-[720px] select-none overflow-hidden"
+            className="relative h-[clamp(280px,52vh,520px)] max-w-[720px] select-none overflow-hidden"
             style={{
                 marginLeft: `-${glowBufferPx}px`,
                 marginRight: `-${glowBufferPx}px`,

--- a/src/components/visualizer/monet/MonetLyricsRail.tsx
+++ b/src/components/visualizer/monet/MonetLyricsRail.tsx
@@ -4,6 +4,7 @@ import type { Theme, AudioBands, Line } from '../../../types';
 import { resolveThemeFontWeight } from '../../../utils/fontStacks';
 import type { GraphemeTiming } from '../../../utils/lyrics/graphemeTiming';
 import { getLineRenderEndTime } from '../../../utils/lyrics/renderHints';
+import { useFontsEpoch } from '../../../hooks/useFontsEpoch';
 import { colorWithAlpha, mixColors } from '../colorMix';
 import {
     buildWordColorRangesFromMatchers,
@@ -16,6 +17,7 @@ import {
     MONET_RAIL_BASE_MAX_HEIGHT_PX,
     MONET_RAIL_BASE_MAX_WIDTH_PX,
     buildMonetDisplayTokens,
+    clearMonetMeasurementCaches,
     measureMonetGraphemeOffsets,
     measureMonetLineLayout,
     resolveMonetSweepEdgeSoftness,
@@ -531,9 +533,11 @@ const MonetWordSweep: React.FC<{
 }) => {
         const isLineActive = lineStatus === 'active';
         const canRenderGlow = lineStatus === 'active' || lineStatus === 'passed';
+        const fontsEpoch = useFontsEpoch();
         const graphemeOffsets = useMemo(
             () => measureMonetGraphemeOffsets(text, fontPx, fontSpec),
-            [text, fontPx, fontSpec],
+            // eslint-disable-next-line react-hooks/exhaustive-deps -- fontsEpoch re-measures once the real face loads
+            [text, fontPx, fontSpec, fontsEpoch],
         );
 
         const wordStatus = useTransform(currentTime, latest => (
@@ -895,6 +899,8 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
     const touchDirectionRef = useRef(0);
     const [manualScrollAnchorIndex, setManualScrollAnchorIndex] = useState<number | null>(null);
     const railSize = useMonetRailSize(railRef);
+    const fontsEpoch = useFontsEpoch();
+    const handledFontsEpochRef = useRef(0);
     const glowBufferPx = Math.round(lyricFontPx * 1.2);
     const vGlowBufferPx = Math.round(lyricFontPx * 1.2);
     // Grows with the same factor as the font, so the column-to-font ratio — and the wrapping — holds.
@@ -916,22 +922,33 @@ const MonetLyricsRail: React.FC<MonetLyricsRailProps> = ({
     const isManualScrolling = manualScrollAnchorIndex !== null;
 
     const positionedEntries = useMemo(
-        () => buildPositionedEntries(
-            visibleEntries,
-            railSize,
-            theme,
-            lyricFontPx,
-            inactiveFontPx,
-            translationFontPx,
-            fontStack,
-            translationFontStack,
-            lyricFontWeight,
-            translationFontWeight,
-            glowBufferPx,
-            showSubtitleTranslation,
-            layoutCacheRef.current,
-        ),
-        [visibleEntries, railSize, theme, lyricFontPx, inactiveFontPx, translationFontPx, fontStack, translationFontStack, lyricFontWeight, translationFontWeight, glowBufferPx, showSubtitleTranslation],
+        () => {
+            // A line measured against a fallback face wraps differently from what is painted, which
+            // under-reserves its height and drops the translation onto the next lyric. Invalidate
+            // here rather than in an effect, so the recompute below already sees fresh metrics.
+            if (handledFontsEpochRef.current !== fontsEpoch) {
+                handledFontsEpochRef.current = fontsEpoch;
+                clearMonetMeasurementCaches();
+                layoutCacheRef.current.clear();
+            }
+
+            return buildPositionedEntries(
+                visibleEntries,
+                railSize,
+                theme,
+                lyricFontPx,
+                inactiveFontPx,
+                translationFontPx,
+                fontStack,
+                translationFontStack,
+                lyricFontWeight,
+                translationFontWeight,
+                glowBufferPx,
+                showSubtitleTranslation,
+                layoutCacheRef.current,
+            );
+        },
+        [visibleEntries, railSize, theme, lyricFontPx, inactiveFontPx, translationFontPx, fontStack, translationFontStack, lyricFontWeight, translationFontWeight, glowBufferPx, showSubtitleTranslation, fontsEpoch],
     );
     const wordColorMatchers = useMemo(
         () => prepareWordColorMatchers(theme.wordColors, keywordColoringEnabled),

--- a/src/components/visualizer/monet/VisualizerMonet.tsx
+++ b/src/components/visualizer/monet/VisualizerMonet.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, useMotionValueEvent, useDragControls, useMotionValue } from 'framer-motion';
 import { RotateCcw } from 'lucide-react';
+import { useElementWidth } from '../../../hooks/useElementWidth';
 import { DEFAULT_MONET_TUNING } from '../../../types';
 import { colorWithAlpha } from '../colorMix';
 import { type VisualizerSharedProps } from '../definition';
@@ -80,6 +81,7 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
 
     const dragControls = useDragControls();
     const isDraggingRef = useRef(false);
+    const shellRef = useRef<HTMLDivElement | null>(null);
 
     const [introKey, setIntroKey] = useState(0);
     const lastTimeRef = useRef(0);
@@ -129,6 +131,7 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
         upcomingLine,
     ]);
 
+    const shellWidth = useElementWidth(shellRef);
     const lyricFontStack = useMemo(() => resolveThemeFontStack(theme), [theme]);
     const translationFontStack = useMemo(
         () => resolveThemeTranslationFontStack(subtitleTheme ?? theme),
@@ -136,7 +139,9 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
     );
     const fontScale = monetTuning.fontScale;
     // Scales the whole composition up on very wide displays; 1 below 2xl, so nothing else changes.
-    const largeScreenScale = resolveMonetLargeScreenScale();
+    // Driven by the observed shell width so a resize re-lays the scene out instead of keeping the
+    // width read at mount, and so an embedded preview scales by its own box, not by the display.
+    const largeScreenScale = resolveMonetLargeScreenScale(shellWidth);
     const lyricFontPx = resolveClampFontPx(
         1.34,
         2.75,
@@ -178,7 +183,7 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
                 </motion.div>
             )}
 
-            <div className="relative z-10 flex h-full w-full items-center justify-center overflow-hidden">
+            <div ref={shellRef} className="relative z-10 flex h-full w-full items-center justify-center overflow-hidden">
                 <div
                     className="flex h-full w-full flex-row items-center overflow-hidden"
                     style={{ maxWidth: `${rowMaxWidthPx}px` }}

--- a/src/components/visualizer/monet/VisualizerMonet.tsx
+++ b/src/components/visualizer/monet/VisualizerMonet.tsx
@@ -13,7 +13,14 @@ import { resolveLyricAlternateText, resolveSubtitleContentMode } from '../../../
 import AudioOverlay from './AudioOverlay';
 import MonetFloatingDecor from './MonetFloatingDecor';
 import MonetLyricsRail from './MonetLyricsRail';
-import { buildMonetVisibleLineEntries, resolveClampFontPx } from './monetLyricsModel';
+import {
+    MONET_PORTRAIT_BASE_MAX_PX,
+    MONET_PORTRAIT_INNER_BASE_MAX_PX,
+    MONET_ROW_BASE_MAX_WIDTH_PX,
+    buildMonetVisibleLineEntries,
+    resolveClampFontPx,
+    resolveMonetLargeScreenScale,
+} from './monetLyricsModel';
 
 // src/components/visualizer/monet/VisualizerMonet.tsx
 // Monet keeps the poster layout here while its lyric rail owns measured scrolling and line states.
@@ -128,13 +135,20 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
         [subtitleTheme, theme],
     );
     const fontScale = monetTuning.fontScale;
+    // Scales the whole composition up on very wide displays; 1 below 2xl, so nothing else changes.
+    const largeScreenScale = resolveMonetLargeScreenScale();
     const lyricFontPx = resolveClampFontPx(
         1.34,
         2.75,
         2.28,
-    ) * fontScale;
-    const inactiveFontPx = resolveClampFontPx(1.08, 2, 1.48) * fontScale;
-    const translationFontPx = resolveClampFontPx(0.94, 1.28, 1.14) * fontScale * subtitleFontScale;
+    ) * fontScale * largeScreenScale;
+    const inactiveFontPx = resolveClampFontPx(1.08, 2, 1.48) * fontScale * largeScreenScale;
+    const translationFontPx = resolveClampFontPx(0.94, 1.28, 1.14) * fontScale * subtitleFontScale * largeScreenScale;
+    const rowMaxWidthPx = Math.round(MONET_ROW_BASE_MAX_WIDTH_PX * largeScreenScale);
+    const portraitMaxPx = Math.round(MONET_PORTRAIT_BASE_MAX_PX * largeScreenScale);
+    const portraitInnerMaxPx = Math.round(MONET_PORTRAIT_INNER_BASE_MAX_PX * largeScreenScale);
+    const titleMaxRem = (2.8 * largeScreenScale).toFixed(3);
+    const artistMaxRem = (1.8 * largeScreenScale).toFixed(3);
 
     /* eslint-disable-next-line no-warning-comments -- @AI: KEEP THIS EXACTLY AS IS */
     // @note Version Control: Project Folia version 0.5.27-a16525c
@@ -165,17 +179,24 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
             )}
 
             <div className="relative z-10 flex h-full w-full items-center justify-center overflow-hidden">
-                <div className="flex h-full w-full max-w-[1520px] flex-row items-center overflow-hidden">
+                <div
+                    className="flex h-full w-full flex-row items-center overflow-hidden"
+                    style={{ maxWidth: `${rowMaxWidthPx}px` }}
+                >
                     {showText && (
-                        <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center px-5 py-5 sm:px-8 sm:py-6 lg:px-14 lg:py-8">
+                        <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center px-5 py-5 sm:px-8 sm:py-6 lg:px-14 lg:py-8 2xl:px-20">
                             <div className="mb-3 space-y-1.5">
                                 <motion.div
                                     key={`artist-${introKey}`}
                                     initial={{ opacity: 0, x: -30, y: -10 }}
                                     animate={{ opacity: 1, x: 0, y: 0 }}
                                     transition={{ duration: 1.2, ease: [0.25, 1, 0.5, 1], delay: 0.15 }}
-                                    className="text-[clamp(1rem,1.8vw,1.8rem)] italic"
-                                    style={{ color: colorWithAlpha(theme.primaryColor, 0.96), letterSpacing: 0 }}
+                                    className="italic"
+                                    style={{
+                                        color: colorWithAlpha(theme.primaryColor, 0.96),
+                                        fontSize: `clamp(1rem, 1.8vw, ${artistMaxRem}rem)`,
+                                        letterSpacing: 0,
+                                    }}
                                 >
                                     {primaryMetaLabel}
                                 </motion.div>
@@ -203,7 +224,7 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
                                         className="font-semibold leading-[1.06]"
                                         style={{
                                             color: theme.primaryColor,
-                                            fontSize: 'clamp(1.45rem, 3.3vw, 2.8rem)',
+                                            fontSize: `clamp(1.45rem, 3.3vw, ${titleMaxRem}rem)`,
                                             letterSpacing: 0,
                                             textShadow: `0 14px 36px ${colorWithAlpha(theme.backgroundColor, 0.28)}`,
                                         }}
@@ -244,6 +265,7 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
                                     audioBands={audioBands}
                                     onLyricLineSeek={onLyricLineSeek}
                                     seekDisabled={isPreviewMode}
+                                    layoutScale={largeScreenScale}
                                 />
                             </motion.div>
 
@@ -278,10 +300,13 @@ const VisualizerMonet: React.FC<VisualizerMonetProps> = (props) => {
                             animate={{ opacity: 1, x: 0, scale: 1, rotate: 0 }}
                             transition={{ duration: 1.6, ease: [0.25, 1, 0.5, 1], delay: 0.25 }}
                             className="hidden min-w-0 items-center justify-center overflow-visible px-3 pr-5 sm:pr-8 md:flex lg:justify-end lg:pr-10 xl:pr-12 select-none"
-                            style={{ flex: '0 0 clamp(220px, 28vw, 430px)' }}
+                            style={{ flex: `0 0 clamp(220px, 28vw, ${portraitMaxPx}px)` }}
                         >
                             {/* Bounding box wrapper that stays in the default position */}
-                            <div className="relative w-full max-w-[clamp(210px,26vw,380px)]">
+                            <div
+                                className="relative w-full"
+                                style={{ maxWidth: `clamp(210px, 26vw, ${portraitInnerMaxPx}px)` }}
+                            >
                                 
                                 {/* Dashed movable region border */}
                                 {isEditingPosition && (

--- a/src/components/visualizer/monet/monetLyricsModel.ts
+++ b/src/components/visualizer/monet/monetLyricsModel.ts
@@ -50,6 +50,7 @@ export interface MonetMeasuredLineLayout {
     lineHeightPx: number;
     translationLineHeightPx: number;
     isTextClipped: boolean;
+    isTextOverflowingWidth: boolean;
     isTranslationClipped: boolean;
 }
 
@@ -89,6 +90,15 @@ const MONET_MIN_MEASURE_WIDTH_PX = 180;
 const MONET_GRAPHEME_OFFSETS_CACHE_LIMIT = 420;
 const MONET_VERTICAL_METRICS_CACHE_LIMIT = 420;
 const MONET_GLYPH_VERTICAL_SAFETY_PX = 2;
+// Below 2xl nothing scales, so every existing viewport keeps its current layout exactly.
+const MONET_LARGE_SCREEN_MIN_PX = 1536;
+const MONET_LARGE_SCREEN_FULL_PX = 2200;
+const MONET_LARGE_SCREEN_MAX_SCALE = 1.16;
+export const MONET_RAIL_BASE_MAX_WIDTH_PX = 780;
+export const MONET_RAIL_BASE_MAX_HEIGHT_PX = 520;
+export const MONET_ROW_BASE_MAX_WIDTH_PX = 1520;
+export const MONET_PORTRAIT_BASE_MAX_PX = 430;
+export const MONET_PORTRAIT_INNER_BASE_MAX_PX = 380;
 
 const monetGraphemeOffsetsCache = new Map<string, number[]>();
 const monetVerticalMetricsCache = new Map<string, number>();
@@ -107,6 +117,27 @@ export {
     type WordColorRange as MonetWordColorRange,
 } from '../wordColoring';
 
+/**
+ * Every Monet clamp tops out between a ~1200px and ~1600px viewport, so anything wider leaves the
+ * whole composition stranded as a small island in the middle of the screen. Past 2xl the layout
+ * scales up as one piece instead of sitting at its cap.
+ *
+ * Font sizes and the lyric column share this factor, so the column-width to font-size ratio — and
+ * therefore how much text fits on a line — stays constant. Scaling up must not change wrapping.
+ */
+export const resolveMonetLargeScreenScale = (): number => {
+    const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : VIEWPORT_WIDTH_FALLBACK_PX;
+    if (viewportWidth <= MONET_LARGE_SCREEN_MIN_PX) {
+        return 1;
+    }
+
+    const progress = Math.min(
+        1,
+        (viewportWidth - MONET_LARGE_SCREEN_MIN_PX) / (MONET_LARGE_SCREEN_FULL_PX - MONET_LARGE_SCREEN_MIN_PX),
+    );
+    return 1 + (MONET_LARGE_SCREEN_MAX_SCALE - 1) * progress;
+};
+
 export const resolveClampFontPx = (minRem: number, preferredVw: number, maxRem: number): number => {
     const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : VIEWPORT_WIDTH_FALLBACK_PX;
     return Math.min(maxRem * ROOT_FONT_PX, Math.max(minRem * ROOT_FONT_PX, viewportWidth * (preferredVw / 100)));
@@ -123,16 +154,16 @@ export const splitMonetGraphemes = (text: string): string[] => {
 };
 
 /**
- * Counts the wrapped lines the rail will actually render for a lyric line.
+ * Measures the wrapped line count and widest line the rail will actually render for a lyric line.
  * Timed words render as `inline-block` spans (see MonetWordSweep), so the browser may only break
  * between tokens, never inside one. Measuring `fullText` as a plain string breaks anywhere and
  * disagrees with the DOM — most visibly on CJK lyrics, whose phrase tokens carry no spaces.
  * `break: 'never'` reproduces those atomic boxes, so the reserved height matches what is painted.
  */
-const measureLyricLineCount = (line: Line, fontSpec: string, maxWidthPx: number): number => {
+const measureLyricLineStats = (line: Line, fontSpec: string, maxWidthPx: number): { lineCount: number; maxLineWidthPx: number; } => {
     const tokens = buildMonetDisplayTokens(line);
     if (tokens.length === 0) {
-        return 1;
+        return { lineCount: 1, maxLineWidthPx: 0 };
     }
 
     const items: RichInlineItem[] = tokens.map(token => ({
@@ -140,11 +171,11 @@ const measureLyricLineCount = (line: Line, fontSpec: string, maxWidthPx: number)
         font: fontSpec,
         break: token.timed ? 'never' : 'normal',
     }));
-    const { lineCount } = measureRichInlineStats(
+    const { lineCount, maxLineWidth } = measureRichInlineStats(
         prepareRichInline(items),
         Math.max(maxWidthPx, MONET_MIN_MEASURE_WIDTH_PX),
     );
-    return Math.max(lineCount, 1);
+    return { lineCount: Math.max(lineCount, 1), maxLineWidthPx: maxLineWidth };
 };
 
 const measureTextLineCount = (text: string, fontSpec: string, maxWidthPx: number, lineHeightPx: number): number => {
@@ -457,7 +488,7 @@ export const measureMonetLineLayout = ({
     const textPaddingBottomPx = Math.max(fontPx * 0.34, 14);
     const translationPaddingTopPx = Math.max(translationFontPx * 0.45, 7);
     const translationPaddingBottomPx = Math.max(translationFontPx * 0.18, 5);
-    const textLineCount = measureLyricLineCount(line, fontSpec, maxWidthPx);
+    const { lineCount: textLineCount, maxLineWidthPx } = measureLyricLineStats(line, fontSpec, maxWidthPx);
     const textLimit = status === 'active' ? MONET_ACTIVE_TEXT_LINE_LIMIT : MONET_INACTIVE_TEXT_LINE_LIMIT;
     const visibleTextLineCount = Math.min(textLineCount, textLimit);
     const hasActiveTranslation = showSubtitleTranslation && status === 'active' && Boolean(line.translation?.trim());
@@ -488,6 +519,9 @@ export const measureMonetLineLayout = ({
         lineHeightPx,
         translationLineHeightPx,
         isTextClipped: textLineCount > visibleTextLineCount,
+        // A token wider than the column (a long compound word) overruns the text box and would be
+        // sliced mid-glyph by `overflow: hidden`. The rail fades that edge out instead.
+        isTextOverflowingWidth: maxLineWidthPx > maxWidthPx,
         isTranslationClipped: rawTranslationLineCount > translationLineCount,
     };
 };

--- a/src/components/visualizer/monet/monetLyricsModel.ts
+++ b/src/components/visualizer/monet/monetLyricsModel.ts
@@ -83,7 +83,9 @@ const VIEWPORT_WIDTH_FALLBACK_PX = 1280;
 // The active lyric is never truncated: its box is content-driven at render time.
 // This cap only bounds the vertical track height the rail reserves for positioning,
 // so a mis-parsed multi-hundred-character line cannot blow up the whole rail geometry.
-const MONET_ACTIVE_TEXT_LINE_LIMIT = 8;
+// Reserving too few rows makes the active block overlap its neighbours, and large font scales
+// on a narrow column reach high row counts legitimately, so keep the guard well clear of them.
+const MONET_ACTIVE_TEXT_LINE_LIMIT = 14;
 const MONET_INACTIVE_TEXT_LINE_LIMIT = 2;
 const MONET_TRANSLATION_LINE_LIMIT = 2;
 const MONET_MIN_MEASURE_WIDTH_PX = 180;

--- a/src/components/visualizer/monet/monetLyricsModel.ts
+++ b/src/components/visualizer/monet/monetLyricsModel.ts
@@ -127,15 +127,19 @@ export {
  * Font sizes and the lyric column share this factor, so the column-width to font-size ratio — and
  * therefore how much text fits on a line — stays constant. Scaling up must not change wrapping.
  */
-export const resolveMonetLargeScreenScale = (): number => {
-    const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : VIEWPORT_WIDTH_FALLBACK_PX;
-    if (viewportWidth <= MONET_LARGE_SCREEN_MIN_PX) {
+export const resolveMonetLargeScreenScale = (containerWidthPx?: number): number => {
+    // Prefer the renderer's own width: an embedded preview on a large display must not scale itself
+    // up as if it owned the screen. Falls back to the viewport before the first measurement lands.
+    const referenceWidth = containerWidthPx && containerWidthPx > 0
+        ? containerWidthPx
+        : typeof window !== 'undefined' ? window.innerWidth : VIEWPORT_WIDTH_FALLBACK_PX;
+    if (referenceWidth <= MONET_LARGE_SCREEN_MIN_PX) {
         return 1;
     }
 
     const progress = Math.min(
         1,
-        (viewportWidth - MONET_LARGE_SCREEN_MIN_PX) / (MONET_LARGE_SCREEN_FULL_PX - MONET_LARGE_SCREEN_MIN_PX),
+        (referenceWidth - MONET_LARGE_SCREEN_MIN_PX) / (MONET_LARGE_SCREEN_FULL_PX - MONET_LARGE_SCREEN_MIN_PX),
     );
     return 1 + (MONET_LARGE_SCREEN_MAX_SCALE - 1) * progress;
 };

--- a/src/components/visualizer/monet/monetLyricsModel.ts
+++ b/src/components/visualizer/monet/monetLyricsModel.ts
@@ -78,7 +78,10 @@ interface MeasureMonetLineLayoutOptions {
 
 const ROOT_FONT_PX = 16;
 const VIEWPORT_WIDTH_FALLBACK_PX = 1280;
-const MONET_ACTIVE_TEXT_LINE_LIMIT = 3;
+// The active lyric is never truncated: its box is content-driven at render time.
+// This cap only bounds the vertical track height the rail reserves for positioning,
+// so a mis-parsed multi-hundred-character line cannot blow up the whole rail geometry.
+const MONET_ACTIVE_TEXT_LINE_LIMIT = 8;
 const MONET_INACTIVE_TEXT_LINE_LIMIT = 2;
 const MONET_TRANSLATION_LINE_LIMIT = 2;
 const MONET_MIN_MEASURE_WIDTH_PX = 180;

--- a/src/components/visualizer/monet/monetLyricsModel.ts
+++ b/src/components/visualizer/monet/monetLyricsModel.ts
@@ -1,4 +1,4 @@
-import { layoutWithLines, prepareWithSegments } from '@chenglou/pretext';
+import { clearCache, layoutWithLines, prepareWithSegments } from '@chenglou/pretext';
 import { measureRichInlineStats, prepareRichInline, type RichInlineItem } from '@chenglou/pretext/rich-inline';
 import type { Line } from '../../../types';
 import { buildLineGraphemeTimeline, buildWordGraphemeTimings, type GraphemeTiming } from '../../../utils/lyrics/graphemeTiming';
@@ -228,6 +228,19 @@ const measureMonetLineHeight = (text: string, fontSpec: string, fontPx: number, 
     }
     monetVerticalMetricsCache.set(cacheKey, measuredLineHeightPx);
     return measuredLineHeightPx;
+};
+
+/**
+ * Drops every cached text measurement.
+ *
+ * Metrics measured while a web font was still loading came from a fallback face, and the cache keys
+ * (the font shorthand string) are identical before and after the load, so they never expire on their
+ * own. Call this when `useFontsEpoch` advances.
+ */
+export const clearMonetMeasurementCaches = () => {
+    monetVerticalMetricsCache.clear();
+    monetGraphemeOffsetsCache.clear();
+    clearCache();
 };
 
 const measureTextWidthAtPx = (text: string, fontPx: number, fontSpec: string): number => {

--- a/src/components/visualizer/monet/monetLyricsModel.ts
+++ b/src/components/visualizer/monet/monetLyricsModel.ts
@@ -1,4 +1,5 @@
 import { layoutWithLines, prepareWithSegments } from '@chenglou/pretext';
+import { measureRichInlineStats, prepareRichInline, type RichInlineItem } from '@chenglou/pretext/rich-inline';
 import type { Line } from '../../../types';
 import { buildLineGraphemeTimeline, buildWordGraphemeTimings, type GraphemeTiming } from '../../../utils/lyrics/graphemeTiming';
 import { getLineRenderEndTime } from '../../../utils/lyrics/renderHints';
@@ -121,8 +122,33 @@ export const splitMonetGraphemes = (text: string): string[] => {
     return Array.from(text);
 };
 
+/**
+ * Counts the wrapped lines the rail will actually render for a lyric line.
+ * Timed words render as `inline-block` spans (see MonetWordSweep), so the browser may only break
+ * between tokens, never inside one. Measuring `fullText` as a plain string breaks anywhere and
+ * disagrees with the DOM — most visibly on CJK lyrics, whose phrase tokens carry no spaces.
+ * `break: 'never'` reproduces those atomic boxes, so the reserved height matches what is painted.
+ */
+const measureLyricLineCount = (line: Line, fontSpec: string, maxWidthPx: number): number => {
+    const tokens = buildMonetDisplayTokens(line);
+    if (tokens.length === 0) {
+        return 1;
+    }
+
+    const items: RichInlineItem[] = tokens.map(token => ({
+        text: token.text,
+        font: fontSpec,
+        break: token.timed ? 'never' : 'normal',
+    }));
+    const { lineCount } = measureRichInlineStats(
+        prepareRichInline(items),
+        Math.max(maxWidthPx, MONET_MIN_MEASURE_WIDTH_PX),
+    );
+    return Math.max(lineCount, 1);
+};
+
 const measureTextLineCount = (text: string, fontSpec: string, maxWidthPx: number, lineHeightPx: number): number => {
-    const prepared = prepareWithSegments(text || ' ', fontSpec);
+    const prepared = prepareWithSegments(text || ' ', fontSpec, { whiteSpace: 'pre-wrap' });
     const layout = layoutWithLines(prepared, Math.max(maxWidthPx, MONET_MIN_MEASURE_WIDTH_PX), lineHeightPx);
     return Math.max(layout.lines.length, 1);
 };
@@ -431,7 +457,7 @@ export const measureMonetLineLayout = ({
     const textPaddingBottomPx = Math.max(fontPx * 0.34, 14);
     const translationPaddingTopPx = Math.max(translationFontPx * 0.45, 7);
     const translationPaddingBottomPx = Math.max(translationFontPx * 0.18, 5);
-    const textLineCount = measureTextLineCount(line.fullText, fontSpec, maxWidthPx, lineHeightPx);
+    const textLineCount = measureLyricLineCount(line, fontSpec, maxWidthPx);
     const textLimit = status === 'active' ? MONET_ACTIVE_TEXT_LINE_LIMIT : MONET_INACTIVE_TEXT_LINE_LIMIT;
     const visibleTextLineCount = Math.min(textLineCount, textLimit);
     const hasActiveTranslation = showSubtitleTranslation && status === 'active' && Boolean(line.translation?.trim());

--- a/src/hooks/useElementWidth.ts
+++ b/src/hooks/useElementWidth.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+// src/hooks/useElementWidth.ts
+// Tracks an element's rendered width so measured-size layout follows resizes.
+
+/**
+ * Returns the observed border-box width of `ref`, or 0 before the first measurement.
+ *
+ * Reading `window.innerWidth` during render is both unreactive — nothing re-renders on resize — and
+ * wrong for an embedded renderer, where a small preview on a large display would size itself from
+ * the display. Observe the container instead and let the caller decide its fallback.
+ */
+export const useElementWidth = (ref: React.RefObject<HTMLElement | null>): number => {
+    const [width, setWidth] = useState(0);
+
+    useEffect(() => {
+        const node = ref.current;
+        if (!node) {
+            return;
+        }
+
+        const updateWidth = () => {
+            const nextWidth = Math.round(node.clientWidth);
+            setWidth(current => (current === nextWidth ? current : nextWidth));
+        };
+
+        updateWidth();
+
+        if (typeof ResizeObserver === 'undefined') {
+            return;
+        }
+
+        const observer = new ResizeObserver(updateWidth);
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, [ref]);
+
+    return width;
+};
+
+export default useElementWidth;

--- a/src/hooks/useFontsEpoch.ts
+++ b/src/hooks/useFontsEpoch.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+// src/hooks/useFontsEpoch.ts
+// Signals when web fonts finish loading so measured-text layout can be recomputed.
+
+/**
+ * Returns a counter that increments every time the document finishes loading web fonts.
+ *
+ * Canvas text measurement (`measureText`, and pretext on top of it) silently falls back to another
+ * face while a web font is still in flight, and the metrics can be ~16% off — enough to change where
+ * a lyric line wraps. Measurement caches are keyed by the font *string*, which is identical before
+ * and after the load, so a stale measurement would otherwise survive for the whole session.
+ *
+ * Take this as a dependency wherever measured text drives layout, and clear the matching caches when
+ * it changes. `loadingdone` is observed as well as `ready`, so fonts pulled in later — a theme switch
+ * or a user-uploaded lyric font — invalidate the measurements too.
+ */
+export const useFontsEpoch = (): number => {
+    const [epoch, setEpoch] = useState(0);
+
+    useEffect(() => {
+        const fonts = typeof document !== 'undefined' ? document.fonts : undefined;
+        if (!fonts) {
+            return;
+        }
+
+        let mounted = true;
+        const bump = () => {
+            if (mounted) {
+                setEpoch(value => value + 1);
+            }
+        };
+
+        fonts.ready?.then(bump).catch(() => undefined);
+        fonts.addEventListener?.('loadingdone', bump);
+
+        return () => {
+            mounted = false;
+            fonts.removeEventListener?.('loadingdone', bump);
+        };
+    }, []);
+
+    return epoch;
+};
+
+export default useFontsEpoch;

--- a/src/hooks/useFontsEpoch.ts
+++ b/src/hooks/useFontsEpoch.ts
@@ -25,18 +25,32 @@ export const useFontsEpoch = (): number => {
         }
 
         let mounted = true;
+        // `ready` also settles for the batch that raised `loadingdone`, so let the event win and keep
+        // the promise as the fallback for a batch that finished before this effect subscribed.
+        let loadingDoneSeen = false;
         const bump = () => {
             if (mounted) {
                 setEpoch(value => value + 1);
             }
         };
+        const handleLoadingDone = () => {
+            loadingDoneSeen = true;
+            bump();
+        };
 
-        fonts.ready?.then(bump).catch(() => undefined);
-        fonts.addEventListener?.('loadingdone', bump);
+        fonts.addEventListener?.('loadingdone', handleLoadingDone);
+        // Nothing measured after this point can be stale when every face is already resolved.
+        if (fonts.status !== 'loaded') {
+            fonts.ready?.then(() => {
+                if (!loadingDoneSeen) {
+                    bump();
+                }
+            }).catch(() => undefined);
+        }
 
         return () => {
             mounted = false;
-            fonts.removeEventListener?.('loadingdone', bump);
+            fonts.removeEventListener?.('loadingdone', handleLoadingDone);
         };
     }, []);
 

--- a/test/unit/visualizer/monetSettings.test.ts
+++ b/test/unit/visualizer/monetSettings.test.ts
@@ -33,6 +33,20 @@ vi.mock('@chenglou/pretext', () => ({
     },
 }));
 
+// Monet measures lyric text through the rich-inline helper so timed words stay atomic like the
+// `inline-block` spans the rail renders. Mirror the plain mock's per-character heuristic here.
+vi.mock('@chenglou/pretext/rich-inline', () => ({
+    prepareRichInline: (items: { text: string; }[]) => ({ text: items.map(item => item.text).join('') }),
+    measureRichInlineStats: (prepared: { text?: string; }, maxWidth: number) => {
+        const text = prepared.text || ' ';
+        const charsPerLine = Math.max(1, Math.floor(maxWidth / 10));
+        return {
+            lineCount: Math.max(1, Math.ceil(text.length / charsPerLine)),
+            maxLineWidth: Math.min(text.length, charsPerLine) * 10,
+        };
+    },
+}));
+
 describe('Monet tuning and lyric helpers', () => {
     it('keeps bright wash targets bright in daylight themes instead of pulling them toward dark text color', () => {
         const washColor = resolveWashColor(


### PR DESCRIPTION
close #291

monet使用的是早期pretext的 `prepareWithSegments` 默认方法，此方法与 `display: inline-block` 化的monet token渲染结果不对齐。更换为更精确的 `prepareRichInline` ，同时调整高分屏上的响应式布局，优化长歌词的显示