### PR TITLE
fix: linux下pixijs场景出现黑色渲染错误

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "music-metadata": "^11.14.0",
         "onnxruntime-node": "^1.27.0",
         "opencc-js": "^1.4.1",
-        "pixi.js": "^8.19.0",
+        "pixi.js": "^8.20.1",
         "react": "^19.2.8",
         "react-colorful": "^5.8.0",
         "react-dom": "^19.2.8",
@@ -12313,9 +12313,10 @@
       "license": "MIT"
     },
     "node_modules/pixi.js": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.19.0.tgz",
-      "integrity": "sha512-pq1O6emA/GFjjeF+8d3Pb5t7knD8FsnfWGqQcRjYjsqFZ7QdzG1XgjLDUu0DFJRbafjV5+g8iNLFBx0b9649lg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.20.1.tgz",
+      "integrity": "sha512-akLVBMLvQbaEViqsmVraK0Njer1q4Q4lm4iNKuzvBiFrV8q+6/+HluJN3sWIwO663IBeQtUUS/CaXFJZs6ffXQ==",
+      "license": "MIT",
       "workspaces": [
         "examples",
         "playground"
@@ -12324,7 +12325,7 @@
         "@pixi/colord": "^2.9.6",
         "@types/earcut": "^3.0.0",
         "@webgpu/types": "^0.1.69",
-        "@xmldom/xmldom": "^0.8.13",
+        "@xmldom/xmldom": "^0.8.15",
         "earcut": "^3.0.2",
         "eventemitter3": "^5.0.1",
         "gifuct-js": "^2.1.2",
@@ -12338,9 +12339,10 @@
       }
     },
     "node_modules/pixi.js/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "music-metadata": "^11.14.0",
     "onnxruntime-node": "^1.27.0",
     "opencc-js": "^1.4.1",
-    "pixi.js": "^8.19.0",
+    "pixi.js": "^8.20.1",
     "react": "^19.2.8",
     "react-colorful": "^5.8.0",
     "react-dom": "^19.2.8",

--- a/src/components/visualizer/loadPixi.ts
+++ b/src/components/visualizer/loadPixi.ts
@@ -1,0 +1,36 @@
+// src/components/visualizer/loadPixi.ts
+// The single place a visualizer pulls Pixi in, so the shader precision default is raised before
+// the first program is compiled.
+//
+// Pixi injects `precision mediump float;` into every fragment shader that does not declare its
+// own (`GlProgram.defaultOptions.preferredFragmentPrecision`). On Windows and on Intel/Mesa that
+// costs nothing - their drivers report mediump as 127/127/23, i.e. it already *is* fp32. The
+// NVIDIA Linux driver is the one that takes the qualifier literally: Chromium reaches it through
+// ANGLE on a native `OpenGL ES 3.2` context, and there mediump is real fp16 (getShaderPrecision-
+// Format reports 15/15/10, max finite value 65504).
+//
+// That difference is not cosmetic. Pixi's own NoiseFilter - the grain pass in tempera's and
+// sonnet's post-process chains - computes `fract(sin(dot(gl_FragCoord.xy * uSeed, vec2(12.9898,
+// 78.233))) * 43758.5453)`. The dot product grows linearly with the pixel coordinate, so past
+// roughly `65504 / uSeed` it overflows fp16 to Inf, `sin(Inf)` is NaN, and every pixel beyond
+// that line is written as black. Because the overflow condition is linear in x and y, the
+// boundary is a straight line across the frame: the black triangle reported on Linux + NVIDIA,
+// growing with textureResolution because `gl_FragCoord` grows with it, and varying per scene
+// because `uSeed` is derived from the scene seed. Capping the post-process resolution only moves
+// the seed threshold - at pass resolution 1.0 a seed of 0.95 still overflows on a 1280x720 frame.
+//
+// highp is fp32 on every device that can run this app: GLSL ES 3.00 requires fragment highp, and
+// Pixi 8 is WebGL2/WebGPU only. `ensurePrecision` still downgrades to mediump if a device somehow
+// reports no highp support, which is exactly today's behaviour, so nothing can get worse. Shaders
+// that declare their own precision line are left alone.
+type PixiModule = typeof import('pixi.js');
+
+/**
+ * Must be awaited before any renderer, filter or shader is constructed: `GlProgram.from` caches
+ * compiled sources, so a program built before the flip would keep its mediump variant.
+ */
+export const loadPixi = async (): Promise<PixiModule> => {
+    const pixi = await import('pixi.js');
+    pixi.GlProgram.defaultOptions.preferredFragmentPrecision = 'highp';
+    return pixi;
+};

--- a/src/components/visualizer/sonnet/createSonnetPixiRuntime.ts
+++ b/src/components/visualizer/sonnet/createSonnetPixiRuntime.ts
@@ -35,6 +35,7 @@ import {
     hasSonnetCreditsMetadata,
     resolveSonnetCreditsFrame,
 } from './sonnetCredits';
+import { loadPixi } from '../loadPixi';
 import { sonnetDebugState } from './sonnetDebug';
 import { resolveSonnetSegmentCameraFocus } from './sonnetCameraTracking';
 
@@ -140,7 +141,7 @@ export class SonnetPixiRuntime {
     ) { }
 
     static async create(options: SonnetRuntimeOptions) {
-        const pixi = await import('pixi.js');
+        const pixi = await loadPixi();
         const app = new pixi.Application();
         const width = Math.max(options.host.clientWidth, 320);
         const height = Math.max(options.host.clientHeight, 240);

--- a/src/components/visualizer/tempera/createTemperaPixiRuntime.ts
+++ b/src/components/visualizer/tempera/createTemperaPixiRuntime.ts
@@ -24,6 +24,7 @@ import {
     type TemperaSceneView,
     type TemperaShotView,
 } from './temperaSceneBuilder';
+import { loadPixi } from '../loadPixi';
 import { setTemperaTransitionBlur } from './temperaSceneFilters';
 import { resolveTemperaPalette } from './temperaPalette';
 import {
@@ -211,7 +212,7 @@ export class TemperaPixiRuntime {
     ) { }
 
     static async create(options: TemperaRuntimeOptions) {
-        const pixi = await import('pixi.js');
+        const pixi = await loadPixi();
         const app = new pixi.Application();
         const width = Math.max(options.host.clientWidth, 320);
         const height = Math.max(options.host.clientHeight, 240);

--- a/test/unit/visualizer/loadPixi.test.ts
+++ b/test/unit/visualizer/loadPixi.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// test/unit/visualizer/loadPixi.test.ts
+// The precision default is the whole reason this loader exists: Pixi injects `precision mediump
+// float;` into any fragment shader without its own precision line, and the NVIDIA Linux driver
+// honours that as real fp16 - which overflows NoiseFilter's `dot(gl_FragCoord.xy * uSeed, ...)`
+// to NaN and paints a black wedge across the frame. Guard the flip so it cannot be dropped.
+const glProgram = { defaultOptions: {} as { preferredFragmentPrecision?: string } };
+
+vi.mock('pixi.js', () => ({ GlProgram: glProgram }));
+
+describe('loadPixi', () => {
+    it('raises the fragment shader precision default to highp', async () => {
+        const { loadPixi } = await import('@/components/visualizer/loadPixi');
+
+        expect(glProgram.defaultOptions.preferredFragmentPrecision).toBeUndefined();
+
+        const pixi = await loadPixi();
+
+        expect(glProgram.defaultOptions.preferredFragmentPrecision).toBe('highp');
+        expect(pixi.GlProgram).toBe(glProgram);
+    });
+});


### PR DESCRIPTION
close #319 

## 原因

pixijs 会为未显式声明精度的 fragment shader 设置 precision mediump float

经测试，NVIDIA + ANGLE/OpenGL ES 环境下mediump为 fp16，最大有限值为 65504。Pixi 内置 NoiseFilter 使用 fract(sin(dot(gl_FragCoord.xy * uSeed, vec2(12.9898, 78.233))) * 43758.5453) 生成噪声；随着像素坐标增大，dot 结果超过 fp16 范围后溢出为 Inf，导致最终合成所在的区域全黑。

## 解决方案

没有出现问题的 intel + Linux / windows 下，mediump 是fp32, 因此直接显式注入 

`pixi.GlProgram.defaultOptions.preferredFragmentPrecision = 'highp';`