### PR TITLE
fix:全局透明背景

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1521,7 +1521,7 @@ export default function App() {
     // click-through is managed by the main process), so the whole custom titlebar strip stays off.
     const usesCustomWindowChrome = isElectronWindow && !wallpaperMode;
     const isPlayerPageTransparent = transparentPlayerBackground || enablePlayerPageNativeBlur;
-    const shouldUseTransparentAppBackground = currentView === 'player' && isPlayerPageTransparent;
+    const shouldUseTransparentAppBackground = isPlayerPageTransparent;
     const appStyle = useMemo(() => buildAppStyle({
         bgMode,
         isDaylight,

--- a/src/components/visualizer/useVisualizerRendererModel.ts
+++ b/src/components/visualizer/useVisualizerRendererModel.ts
@@ -107,14 +107,14 @@ export const useVisualizerRendererModel = ({
 
     const background = useMemo<VisualizerBackgroundConfig>(() => ({
         ...backgroundConfig,
-        transparent: currentView === 'player' && isPlayerPageTransparent && !isSettingsModalOpen,
+        transparent: isPlayerPageTransparent,
         common: {
             ...backgroundConfig.common,
             // A settings subview covers the geometry anyway, and drawing it under an opaque panel
             // is the one place the cost buys nothing.
             disableGeometricBackground: disableGeometricBackground || isSettingsSubviewOpen,
         },
-    }), [backgroundConfig, currentView, isPlayerPageTransparent, isSettingsModalOpen, disableGeometricBackground, isSettingsSubviewOpen]);
+    }), [backgroundConfig, isPlayerPageTransparent, disableGeometricBackground, isSettingsSubviewOpen]);
 
     const mode: VisualizerMode = isObsBrowserSourceRendering ? 'still' : visualizerMode;
 


### PR DESCRIPTION
透明背景开放到全 app，这个仅播放页透明的限制搞的透明背景效果有些割裂感

## 前后的效果对比

https://github.com/user-attachments/assets/1160a91c-728e-4aa8-8869-3699af3b105c


