### PR TITLE
fix(ai): 补齐 OpenAI 主题 schema 中的 description required 属性

### DIFF
--- a/api-ts/generate-theme_openai.ts
+++ b/api-ts/generate-theme_openai.ts
@@ -45,7 +45,7 @@ const THEME_JSON_SCHEMA = {
                     items: { type: 'string' }
                 }
             },
-            required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
+            required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
         },
         dark: {
             type: 'object',
@@ -77,7 +77,7 @@ const THEME_JSON_SCHEMA = {
                     items: { type: 'string' }
                 }
             },
-            required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
+            required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
         }
     },
     required: ['light', 'dark']

--- a/api/generate-theme_openai.js
+++ b/api/generate-theme_openai.js
@@ -42,7 +42,7 @@ const THEME_JSON_SCHEMA = {
                     items: { type: 'string' }
                 }
             },
-            required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
+            required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
         },
         dark: {
             type: 'object',
@@ -74,7 +74,7 @@ const THEME_JSON_SCHEMA = {
                     items: { type: 'string' }
                 }
             },
-            required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
+            required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
         }
     },
     required: ['light', 'dark']

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -2435,7 +2435,7 @@ const THEME_JSON_SCHEMA = {
           items: { type: 'string' }
         },
       },
-      required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons'],
+      required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons'],
     },
     dark: {
       type: 'object',
@@ -2467,7 +2467,7 @@ const THEME_JSON_SCHEMA = {
           items: { type: 'string' }
         },
       },
-      required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons'],
+      required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons'],
     },
   },
   required: ['light', 'dark'],

--- a/worker/generate-theme_openai.ts
+++ b/worker/generate-theme_openai.ts
@@ -47,7 +47,7 @@ const THEME_JSON_SCHEMA = {
                     items: { type: 'string' }
                 }
             },
-            required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
+            required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
         },
         dark: {
             type: 'object',
@@ -79,7 +79,7 @@ const THEME_JSON_SCHEMA = {
                     items: { type: 'string' }
                 }
             },
-            required: ['name', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
+            required: ['name', 'description', 'backgroundColor', 'primaryColor', 'accentColor', 'secondaryColor', 'wordColors', 'lyricsIcons']
         }
     },
     required: ['light', 'dark']


### PR DESCRIPTION
### 描述

在使用 OpenAI 兼容接口生成主题时，若启用结构化输出（Structured Outputs，即 `response_format: { type: 'json_schema', json_schema: { strict: true } }`），OpenAI 规范要求 `strict: true` 模式下对象的 `properties` 中声明的所有字段必须全部出现在 `required` 列表中。

此前 `THEME_JSON_SCHEMA` 在 `light` 与 `dark` 对象的 `properties` 中定义了 `description`，但 `required` 数组中遗漏了 `'description'`。在官方端点或对 Schema 进行严格校验的第三方网关上调用时，会返回 HTTP 400 报错：
```
Invalid schema for response_format 'dual_theme': In context=('properties', 'dark'), 'required' is required to be supplied and to be an array including every key in properties. Missing 'description'.
```

### 修改内容

在以下 4 个文件中，将 `'description'` 补充至 `light` 和 `dark` 的 `required` 属性列表：
- `electron/main.cjs`
- `api-ts/generate-theme_openai.ts`
- `api/generate-theme_openai.js`
- `worker/generate-theme_openai.ts`

### 影响与测试

- 数据清洗逻辑（`sanitizeTheme`）和提示词中原本就包含对 `description` 的处理，本次修改仅补齐 Schema 的严格合规性。
- 无破坏性变更，兼容已有的主题解析与生成流程。