### PR TITLE
fix: Mac壁纸模式修复

### DIFF
--- a/electron/macWallpaperController.cjs
+++ b/electron/macWallpaperController.cjs
@@ -165,7 +165,6 @@ function initWindowLevel() {
     const koffi = require('koffi');
     const objc = koffi.load('/usr/lib/libobjc.A.dylib');
     const sel_registerName = objc.func('void* sel_registerName(const char*)');
-    const objc_getClass = objc.func('void* objc_getClass(const char*)');
     const msgSend_ptr = objc.func('objc_msgSend', 'void*', ['void*', 'void*']);
     const msgSend_long = objc.func('objc_msgSend', 'long', ['void*', 'void*']);
     const msgSend_ulong = objc.func('objc_msgSend', 'unsigned long', ['void*', 'void*']);
@@ -190,7 +189,6 @@ function initWindowLevel() {
       ok: true,
       koffi,
       SEL,
-      objc_getClass,
       msgSend_ptr,
       msgSend_long,
       msgSend_ulong,
@@ -437,65 +435,6 @@ function readWindowOcclusionState(win) {
     return Number(s.msgSend_ulong(w, s.SEL('occlusionState')));
   } catch (e) {
     return null;
-  }
-}
-
-// --- NSApplication presentation options ---
-// Electron's simple-full-screen emulation is the pre-Lion kind: entering it calls
-// [NSApp setPresentationOptions:] with AutoHideDock | AutoHideMenuBar, and leaving it restores
-// the options that were current WHEN THE WINDOW ENTERED. Those options are app-level, so a
-// rebuilt window re-entering simple full screen can capture a stale auto-hide value, and the
-// "restore" at exit then strands the auto-hide bits on an ordinary window (focusing the app
-// keeps hiding the menu bar / Dock). main.cjs clears exactly the bits that must not survive a
-// wallpaper session through these helpers, instead of trusting Electron's captured value.
-function sharedApplication() {
-  const s = initWindowLevel();
-  if (!s.ok) return null;
-  try {
-    let nsApplicationClass = s.objc_getClass('NSApplication');
-    if (!nsApplicationClass) {
-      // AppKit is loaded in the Electron main process, but stay self-sufficient: load it so the
-      // class exists (mirrors the dlopen pattern of the event-tap init).
-      try {
-        const libc = s.koffi.load('/usr/lib/libSystem.B.dylib');
-        const dlopen = libc.func('void *dlopen(const char *path, int flags)');
-        dlopen('/System/Library/Frameworks/AppKit.framework/AppKit', 2 /*RTLD_NOW*/);
-        nsApplicationClass = s.objc_getClass('NSApplication');
-      } catch (e) {
-        // ignore
-      }
-    }
-    if (!nsApplicationClass) return null;
-    return s.msgSend_ptr(nsApplicationClass, s.SEL('sharedApplication'));
-  } catch (e) {
-    return null;
-  }
-}
-
-// Returns the app's current NSApplicationPresentationOptions (NSUInteger), or null when the
-// bridge is unavailable.
-function currentAppPresentationOptions() {
-  const s = initWindowLevel();
-  const app = s && s.ok ? sharedApplication() : null;
-  if (!app) return null;
-  try {
-    return Number(s.msgSend_ulong(app, s.SEL('currentSystemPresentationOptions')));
-  } catch (e) {
-    return null;
-  }
-}
-
-// Clears the given presentation-option bits app-wide (fail-soft no-op when unavailable).
-function clearAppPresentationOptions(mask) {
-  const s = initWindowLevel();
-  const app = s && s.ok ? sharedApplication() : null;
-  if (!app) return false;
-  try {
-    const current = Number(s.msgSend_ulong(app, s.SEL('currentSystemPresentationOptions')));
-    s.msgSend_v_ulong(app, s.SEL('setPresentationOptions:'), (current & ~mask) >>> 0);
-    return true;
-  } catch (e) {
-    return false;
   }
 }
 
@@ -927,12 +866,6 @@ function createMacWallpaperController(options = {}) {
     },
     getOcclusionState(win) {
       return readWindowOcclusionState(win);
-    },
-    presentationOptions() {
-      return currentAppPresentationOptions();
-    },
-    clearPresentationOptions(mask) {
-      return clearAppPresentationOptions(mask);
     },
     isVisibleByOcclusion(win) {
       const state = readWindowOcclusionState(win);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -621,17 +621,6 @@ const MAC_WALLPAPER_TAP_RETRY_DELAY_MS = 2000;
 const MAC_WALLPAPER_TAP_FAILURE_THRESHOLD = 3;
 const MAC_WALLPAPER_DRAG_FLUSH_MS = 16;
 
-// NSApplicationPresentationOptions bits involved in the wallpaper session. Electron's
-// simple-full-screen emulation is the pre-Lion kind: entering it sets the APP-LEVEL
-// AutoHideDock | AutoHideMenuBar presentation bits, and leaving it restores whatever options were
-// current when that window entered. The capture can be stale (a rebuilt window enters while the
-// bits are still set; entering while a native full-screen exit is still animating can capture the
-// FullScreen bit), which strands auto-hiding on an ordinary window after exit — focusing Folia
-// keeps hiding the menu bar / Dock until the next wallpaper session clears it.
-const NS_PRESENTATION_AUTOHIDE_DOCK = 1 << 0; // NSApplicationPresentationAutoHideDock
-const NS_PRESENTATION_AUTOHIDE_MENU_BAR = 1 << 2; // NSApplicationPresentationAutoHideMenuBar
-const NS_PRESENTATION_FULL_SCREEN = 1 << 10; // NSApplicationPresentationFullScreen
-
 function isMacWallpaperMode() {
   return process.platform === 'darwin' && isWallpaperModeEnabled();
 }
@@ -662,29 +651,6 @@ function isMacSimpleFullScreen(win) {
   }
   try {
     return win.isSimpleFullScreen();
-  } catch (error) {
-    return false;
-  }
-}
-
-// Clears the app-level presentation bits a wallpaper session must not leave behind. NSApp
-// presentation options survive window rebuilds, and Electron's simple-full-screen bookkeeping can
-// restore a stale capture (see the bit constants above) — so the session clears the AutoHide bits
-// itself before entering simple full screen and again after leaving it. The FullScreen bit is only
-// cleared once the window is no longer in a native full-screen transition (while it is, the system
-// owns that bit).
-function clearMacWallpaperPresentationLeftovers() {
-  const controller = getMacWallpaperController();
-  if (!controller || typeof controller.clearPresentationOptions !== 'function') {
-    return false;
-  }
-  let mask = NS_PRESENTATION_AUTOHIDE_DOCK | NS_PRESENTATION_AUTOHIDE_MENU_BAR;
-  const windowIsNativeFullScreen = Boolean(mainWindow && !mainWindow.isDestroyed());
-  if (!windowIsNativeFullScreen || !mainWindow.isFullScreen()) {
-    mask |= NS_PRESENTATION_FULL_SCREEN;
-  }
-  try {
-    return controller.clearPresentationOptions(mask);
   } catch (error) {
     return false;
   }
@@ -878,7 +844,6 @@ function enterMacWallpaperMode() {
         // ignore
       }
     }
-    clearMacWallpaperPresentationLeftovers();
     applyMacAmbientLevel();
     applyMacWallpaperFrame();
     // Hide the Dock while the wallpaper is up when the decision says so (default: only a bottom
@@ -937,9 +902,6 @@ function exitMacWallpaperMode() {
   if (!mainWindow || mainWindow.isDestroyed()) {
     macWallpaperSavedState = null;
     if (wasActive) {
-      // App-level presentation options survive the window: Electron's simple-full-screen
-      // auto-hide bits would keep hiding the menu bar / Dock for the rest of the process.
-      clearMacWallpaperPresentationLeftovers();
       store.set(WALLPAPER_MODE_SETTING_KEY, false);
       notifyMacWallpaperModeChanged();
     }
@@ -1026,10 +988,6 @@ function exitMacWallpaperMode() {
   } catch (error) {
     console.warn('[WallpaperMac] exit wallpaper mode restore issue:', error && error.message);
   } finally {
-    // Electron's simple-full-screen exit restores the app-level presentation options it captured
-    // on entry — a capture that can be stale (see the bit constants). Force the wallpaper bits off
-    // after the restore so a normal window never keeps hiding the menu bar / Dock on focus.
-    clearMacWallpaperPresentationLeftovers();
     macWallpaperSavedState = null;
     store.set(WALLPAPER_MODE_SETTING_KEY, false);
     notifyMacWallpaperModeChanged();
@@ -1100,10 +1058,6 @@ function rebindMacWallpaperSessionToCurrentWindow() {
         // ignore
       }
     }
-    // Clear stale AutoHide presentation bits before the replacement window enters simple full
-    // screen (the old window's bits survive the swap and would otherwise be captured as the value
-    // Electron restores on exit — the "focusing Folia hides the menu bar" leftover).
-    clearMacWallpaperPresentationLeftovers();
     applyMacAmbientLevel();
     applyMacWallpaperFrame();
     if (shouldMacWallpaperAutohideDock(controller)) {


### PR DESCRIPTION
删了一个把 AppKit 的  _setPresentationOptions: 卡在死循环的机制