### PR TITLE
feat:用户数据清理

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,30 @@
+LangString foliaUserDataPrompt 1033 "Delete user data?"
+LangString foliaUserDataPrompt 2052 "是否删除用户数据？"
+LangString foliaUserDataPrompt 1057 "Hapus data pengguna?"
+
+!macro customUnInstall
+  ; Electron always uses per-user app data, so look under the current user's
+  ; roaming profile even when the installation itself is per-machine.
+  ${if} $installMode == "all"
+    SetShellVarContext current
+  ${endif}
+
+  IfFileExists "$APPDATA\${APP_FILENAME}\*.*" 0 folia_skipUserDataPrompt
+
+  MessageBox MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2 "$(foliaUserDataPrompt)" /SD IDNO IDYES folia_deleteUserData
+  Goto folia_skipUserDataPrompt
+
+  folia_deleteUserData:
+    RMDir /r "$APPDATA\${APP_FILENAME}"
+    !ifdef APP_PRODUCT_FILENAME
+      RMDir /r "$APPDATA\${APP_PRODUCT_FILENAME}"
+    !endif
+    !ifdef APP_PACKAGE_NAME
+      RMDir /r "$APPDATA\${APP_PACKAGE_NAME}"
+    !endif
+
+  folia_skipUserDataPrompt:
+  ${if} $installMode == "all"
+    SetShellVarContext all
+  ${endif}
+!macroend

--- a/package.json
+++ b/package.json
@@ -164,7 +164,13 @@
     },
     "nsis": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "installerLanguages": [
+        "en_US",
+        "zh_CN",
+        "id"
+      ],
+      "include": "build/installer.nsh"
     },
     "linux": {
       "artifactName": "${name}-${version}-linux-${arch}.${ext}",


### PR DESCRIPTION
## 用户数据清理
为 Windows 平台的卸载程序添加了一个用于在卸载时清理程序产生的用户数据选项

<img width="635" height="457" alt="截图" src="https://github.com/user-attachments/assets/5f964d30-b697-4bf0-a2aa-d3756ab6587d" />
