### PR TITLE
fix:主题重置按钮修复

### DIFF
--- a/src/components/modal/ThemePark.tsx
+++ b/src/components/modal/ThemePark.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../types';
 import { getVisualizerModeLabel } from '../visualizer/registry';
 import { normalizeThemeHexColor } from '../../services/themeSanitizer';
+import { BASE_DUAL_THEME } from '../../services/baseThemes';
 import type { ThemeCacheSongKey } from '../../services/themeCache';
 import { extractColors } from '../../utils/colorExtractor';
 import { buildRecommendedColors } from '../../utils/themeEditorPalette';
@@ -130,7 +131,14 @@ const ThemePark: React.FC<ThemeParkProps> = ({
         replaceDraft,
         reset,
         buildFinalTheme,
-    } = useThemeParkDraft({ aiTheme, customTheme, bgMode, seedTheme: initialTheme, isDaylight });
+    } = useThemeParkDraft({
+        aiTheme,
+        customTheme,
+        bgMode,
+        seedTheme: initialTheme,
+        isDaylight,
+        defaultCustomTheme: BASE_DUAL_THEME,
+    });
 
     const { currentTime, audioPower, audioBands, currentLineIndex } = useThemeParkPreviewClock(visualizerMode, isPaused);
 

--- a/src/components/modal/theme-park/useThemeParkDraft.ts
+++ b/src/components/modal/theme-park/useThemeParkDraft.ts
@@ -21,6 +21,7 @@ type UseThemeParkDraftOptions = {
     bgMode: ThemeMode;
     seedTheme: DualTheme;
     isDaylight: boolean;
+    defaultCustomTheme?: DualTheme;
 };
 
 const resolveInitialTarget = (
@@ -39,6 +40,7 @@ export const useThemeParkDraft = ({
     bgMode,
     seedTheme,
     isDaylight,
+    defaultCustomTheme,
 }: UseThemeParkDraftOptions) => {
     const [target, setTarget] = useState<ThemeEditTarget>(() => resolveInitialTarget(bgMode, aiTheme, customTheme));
     const hasChosenTargetRef = useRef(false);
@@ -148,8 +150,22 @@ export const useThemeParkDraft = ({
 
     const reset = useCallback(() => {
         flushPendingColor();
+        if (target === 'custom' && defaultCustomTheme) {
+            const patchColors = (source: Theme) => ({
+                backgroundColor: source.backgroundColor,
+                primaryColor: source.primaryColor,
+                accentColor: source.accentColor,
+                secondaryColor: source.secondaryColor,
+            });
+            applyDraft(target, previous => ({
+                ...previous,
+                light: { ...previous.light, ...patchColors(defaultCustomTheme.light) },
+                dark: { ...previous.dark, ...patchColors(defaultCustomTheme.dark) },
+            }));
+            return;
+        }
         applyDraft(target, () => baseTheme);
-    }, [applyDraft, baseTheme, flushPendingColor, target]);
+    }, [applyDraft, baseTheme, defaultCustomTheme, flushPendingColor, target]);
 
     // Flushes any in-flight picker value, then hands back a sanitized theme fit to save or copy.
     const buildFinalTheme = useCallback(() => {

--- a/src/components/panelTab/ThemeQuickEditor.tsx
+++ b/src/components/panelTab/ThemeQuickEditor.tsx
@@ -6,6 +6,7 @@ import { useShallow } from 'zustand/react/shallow';
 import type { DualTheme, SongResult } from '../../types';
 import type { ThemeCacheSongKey } from '../../services/themeCache';
 import { FALLBACK_AI_DUAL_THEME, sanitizeDualTheme } from '../../services/themeSanitizer';
+import { BASE_DUAL_THEME } from '../../services/baseThemes';
 import { extractColors } from '../../utils/colorExtractor';
 import { THEME_GENERATION_PROMPT_PREFIX, buildThemeSourcePrompt, parseAiThemeJsonInput } from '../../utils/aiThemePrompts';
 import { useThemeQuickEditorStore, type ThemeQuickEditorKind } from '../../stores/useThemeQuickEditorStore';
@@ -227,6 +228,30 @@ const ThemeQuickEditor: React.FC<ThemeQuickEditorProps> = ({
     };
 
     const handleReset = () => {
+        if (throttleTimeoutRef.current) {
+            clearTimeout(throttleTimeoutRef.current);
+            throttleTimeoutRef.current = null;
+        }
+        if (kind === 'custom') {
+            setDraftTheme(previous => ({
+                ...previous,
+                light: {
+                    ...previous.light,
+                    backgroundColor: BASE_DUAL_THEME.light.backgroundColor,
+                    primaryColor: BASE_DUAL_THEME.light.primaryColor,
+                    accentColor: BASE_DUAL_THEME.light.accentColor,
+                    secondaryColor: BASE_DUAL_THEME.light.secondaryColor,
+                },
+                dark: {
+                    ...previous.dark,
+                    backgroundColor: BASE_DUAL_THEME.dark.backgroundColor,
+                    primaryColor: BASE_DUAL_THEME.dark.primaryColor,
+                    accentColor: BASE_DUAL_THEME.dark.accentColor,
+                    secondaryColor: BASE_DUAL_THEME.dark.secondaryColor,
+                },
+            }));
+            return;
+        }
         setDraftTheme(normalizedInitialTheme);
         setThemeNames({
             light: normalizedInitialTheme.light.name || '',


### PR DESCRIPTION
## 调整了自定义配色编辑页重置按钮的行为。

重置按钮应该是恢复到 **程序预设的主题** 而不是 **用户保存的主题**。

这样更符合直觉一些。否则的话使用重置按钮和直接退出没区别了，而且如果调了个烂配色也恢复不了内置配色。

<img width="651" height="391" alt="图" src="https://github.com/user-attachments/assets/9e7b2d20-d35c-4cc9-9e45-e3fd14520c81" />
