### PR TITLE
fix(kugou): 酷狗新版接口某些歌曲无法播放

### DIFF
--- a/src/services/onlineMusic/kugouProvider.ts
+++ b/src/services/onlineMusic/kugouProvider.ts
@@ -27,6 +27,7 @@ import {
     hasKugouAuthenticatedSearchSession,
     requestKugouAnonymousSearch,
     requestKugou,
+    requestKugouLegacyPlayInfo,
 } from './kugouTransport';
 
 // src/services/onlineMusic/kugouProvider.ts
@@ -980,6 +981,40 @@ export const kugouProvider: OnlineMusicProvider = {
                     }
                 }
             }
+
+            // KuGou's current /song/url can mark certain hashes as unavailable (status: 3)
+            // even though the same hash is still playable through the old mobile endpoint.
+            // Only use this as a last resort after every quality and hash variant above has failed.
+            if (sourceRef?.variant !== 'cloud') {
+                try {
+                    const legacyResponse = await requestKugouLegacyPlayInfo(hash);
+                    const legacyUrl = audioUrlOf(valueOf(legacyResponse, 'url') ?? valueOf(dataOf(legacyResponse), 'url'))
+                        ?? audioUrlOf(valueOf(legacyResponse, 'backup_url') ?? valueOf(dataOf(legacyResponse), 'backup_url'));
+                    if (legacyUrl) {
+                        console.info('[KuGouProvider] playback:url-resolved-legacy', {
+                            hash,
+                            requestedQuality: quality,
+                        });
+                        return {
+                            url: legacyUrl,
+                            fetchedAt: Date.now(),
+                            quality: 'standard',
+                        };
+                    }
+                    console.warn('[KuGouProvider] playback:no-url-legacy', {
+                        hash,
+                        requestedQuality: quality,
+                        status: valueOf(legacyResponse, 'status') ?? valueOf(dataOf(legacyResponse), 'status'),
+                    });
+                } catch (error) {
+                    console.warn('[KuGouProvider] playback:legacy-failed', {
+                        hash,
+                        requestedQuality: quality,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
+                }
+            }
+
             console.warn('[KuGouProvider] playback:unavailable', { hash, requestedQuality: quality, attemptedQualities: qualities });
             return null;
         },

--- a/src/services/onlineMusic/kugouTransport.ts
+++ b/src/services/onlineMusic/kugouTransport.ts
@@ -172,6 +172,51 @@ export const requestKugouAnonymousSearch = async (
     return body;
 };
 
+/**
+ * Legacy mobile play-info fallback used when the current /song/url endpoint refuses a hash.
+ * It is intentionally kept outside the signed Web API transport because it calls KuGou's old
+ * public mobile endpoint and works without the configured VITE_KUGOU_API_BASE.
+ */
+export const requestKugouLegacyPlayInfo = async (hash: string): Promise<any> => {
+    const targetUrl = new URL('https://m.kugou.com/app/i/getSongInfo.php');
+    targetUrl.searchParams.set('cmd', 'playInfo');
+    targetUrl.searchParams.set('hash', hash);
+    const targetUrlString = targetUrl.toString();
+
+    // In Electron, route through the main-process lyric proxy so CORS cannot block this
+    // last-resort mobile endpoint. The Web build uses the same /api/lyric-proxy helper.
+    if (typeof window !== 'undefined' && window.electron?.fetchLyricProxy) {
+        const response = await window.electron.fetchLyricProxy(targetUrlString, { method: 'GET' });
+        if (!response.ok) {
+            throw new OnlineProviderError(
+                'network',
+                `KuGou legacy playInfo failed: ${response.status}`,
+                'kugou',
+            );
+        }
+        return JSON.parse(response.bodyText) as any;
+    }
+
+    const requestUrl = typeof window !== 'undefined' && window.electron
+        ? targetUrlString
+        : `/api/lyric-proxy?url=${encodeURIComponent(targetUrlString)}`;
+    const response = await fetch(requestUrl, {
+        method: 'GET',
+        credentials: 'omit',
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/124.0.0.0 Mobile Safari/537.36',
+        },
+    });
+    if (!response.ok) {
+        throw new OnlineProviderError(
+            'network',
+            `KuGou legacy playInfo failed: ${response.status}`,
+            'kugou',
+        );
+    }
+    return response.json();
+};
+
 const clearWebDeviceIdentity = (): void => {
     removeProviderSessionValue('kugou', 'dfid');
     const storedCookie = readProviderSessionValue('kugou', 'cookie');

--- a/test/unit/onlineMusic/kugouProvider.test.ts
+++ b/test/unit/onlineMusic/kugouProvider.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const requestMock = vi.hoisted(() => vi.fn());
 const anonymousSearchMock = vi.hoisted(() => vi.fn());
+const legacyPlayInfoMock = vi.hoisted(() => vi.fn());
 const transportState = vi.hoisted(() => ({ hasAuthenticatedSearchSession: true }));
 
 vi.mock('@/services/onlineMusic/kugouTransport', () => ({
@@ -11,6 +12,7 @@ vi.mock('@/services/onlineMusic/kugouTransport', () => ({
     hasKugouAuthenticatedSearchSession: () => transportState.hasAuthenticatedSearchSession,
     requestKugouAnonymousSearch: anonymousSearchMock,
     requestKugou: requestMock,
+    requestKugouLegacyPlayInfo: legacyPlayInfoMock,
 }));
 
 vi.mock('@/services/onlineMusic/providerStorage', () => ({
@@ -30,6 +32,7 @@ describe('kugouProvider', () => {
         vi.useRealTimers();
         requestMock.mockReset();
         anonymousSearchMock.mockReset();
+        legacyPlayInfoMock.mockReset();
         transportState.hasAuthenticatedSearchSession = true;
     });
 
@@ -536,6 +539,51 @@ describe('kugouProvider', () => {
                 trackPeak: Math.pow(10, -1.1 / 20),
             },
         });
+    });
+
+    it('uses the legacy mobile playInfo URL when all /song/url variants fail', async () => {
+        requestMock.mockResolvedValue({ status: 3 });
+        legacyPlayInfoMock.mockResolvedValue({
+            status: 1,
+            url: 'https://legacy.example.test/song.mp3',
+            backup_url: 'https://legacy.example.test/backup.mp3',
+        });
+        const song = normalizeKugouSong({
+            FileHash: 'hash', SongName: 'Song', AlbumID: 164446399, album_audio_id: 500617606,
+        });
+
+        const source = await kugouProvider.playback?.getAudioSource(song, 'lossless');
+
+        expect(legacyPlayInfoMock).toHaveBeenCalledWith('HASH');
+        expect(source).toMatchObject({
+            url: 'https://legacy.example.test/song.mp3',
+            quality: 'standard',
+        });
+    });
+
+    it('uses the legacy mobile playInfo backup_url when url is absent', async () => {
+        requestMock.mockResolvedValue({ data: {} });
+        legacyPlayInfoMock.mockResolvedValue({
+            status: 1,
+            backup_url: 'https://legacy.example.test/backup.mp3',
+        });
+        const song = normalizeKugouSong({ FileHash: 'hash', SongName: 'Song' });
+
+        const source = await kugouProvider.playback?.getAudioSource(song, 'high');
+
+        expect(legacyPlayInfoMock).toHaveBeenCalledWith('HASH');
+        expect(source?.url).toBe('https://legacy.example.test/backup.mp3');
+    });
+
+    it('still returns null when the legacy mobile playInfo has no playable URL', async () => {
+        requestMock.mockResolvedValue({ status: 3 });
+        legacyPlayInfoMock.mockResolvedValue({ status: 3 });
+        const song = normalizeKugouSong({ FileHash: 'hash', SongName: 'Song' });
+
+        const source = await kugouProvider.playback?.getAudioSource(song, 'standard');
+
+        expect(legacyPlayInfoMock).toHaveBeenCalledWith('HASH');
+        expect(source).toBeNull();
     });
 
     it('hydrates canonical album and artist ids through hash-verified KRM metadata once', async () => {

--- a/test/unit/onlineMusic/kugouTransport.test.ts
+++ b/test/unit/onlineMusic/kugouTransport.test.ts
@@ -197,6 +197,65 @@ describe('KuGou Web transport', () => {
         expect(kugouRequest).not.toHaveBeenCalled();
     });
 
+    it('builds the legacy mobile playInfo request through the Web lyric proxy', async () => {
+        vi.stubGlobal('window', undefined);
+        const fetchMock = vi.fn().mockResolvedValue(Response.json({
+            status: 1,
+            url: 'https://example.test/song.mp3',
+            backup_url: 'https://example.test/backup.mp3',
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+        const { requestKugouLegacyPlayInfo } = await import('@/services/onlineMusic/kugouTransport');
+
+        const body = await requestKugouLegacyPlayInfo('B18B946D9B510FC72AB848FA17D06AFB');
+
+        expect(body).toMatchObject({ status: 1, url: 'https://example.test/song.mp3' });
+        const proxyUrl = new URL(String(fetchMock.mock.calls[0][0]), 'http://localhost');
+        const targetUrl = new URL(proxyUrl.searchParams.get('url') || '');
+        expect(targetUrl.hostname).toBe('m.kugou.com');
+        expect(targetUrl.pathname).toBe('/app/i/getSongInfo.php');
+        expect(targetUrl.searchParams.get('cmd')).toBe('playInfo');
+        expect(targetUrl.searchParams.get('hash')).toBe('B18B946D9B510FC72AB848FA17D06AFB');
+        expect(fetchMock.mock.calls[0][1]).toMatchObject({ credentials: 'omit' });
+    });
+
+    it('calls the legacy mobile playInfo directly in Electron', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(Response.json({
+            status: 1,
+            url: 'https://example.test/song.mp3',
+        }));
+        vi.stubGlobal('window', { electron: { kugouRequest: vi.fn() } });
+        vi.stubGlobal('fetch', fetchMock);
+        const { requestKugouLegacyPlayInfo } = await import('@/services/onlineMusic/kugouTransport');
+
+        await requestKugouLegacyPlayInfo('HASH');
+
+        const targetUrl = new URL(String(fetchMock.mock.calls[0][0]));
+        expect(targetUrl.hostname).toBe('m.kugou.com');
+        expect(targetUrl.searchParams.get('cmd')).toBe('playInfo');
+        expect(targetUrl.searchParams.get('hash')).toBe('HASH');
+    });
+
+    it('uses the Electron main-process proxy when the legacy mobile playInfo is fetched in desktop', async () => {
+        const fetchLyricProxy = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            bodyText: JSON.stringify({ status: 1, url: 'https://example.test/song.mp3' }),
+        });
+        vi.stubGlobal('window', { electron: { kugouRequest: vi.fn(), fetchLyricProxy } });
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        const { requestKugouLegacyPlayInfo } = await import('@/services/onlineMusic/kugouTransport');
+
+        const body = await requestKugouLegacyPlayInfo('HASH');
+
+        expect(body).toMatchObject({ status: 1, url: 'https://example.test/song.mp3' });
+        const targetUrl = new URL(String(fetchLyricProxy.mock.calls[0][0]));
+        expect(targetUrl.hostname).toBe('m.kugou.com');
+        expect(targetUrl.searchParams.get('cmd')).toBe('playInfo');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('does not fall back to Web after an Electron IPC failure', async () => {
         const ipcError = new Error('ipc failed');
         const kugouRequest = vi.fn().mockRejectedValue(ipcError);


### PR DESCRIPTION
## 问题描述

使用酷狗账号登录后，部分歌曲（例如「翡翠のまち」）在酷狗新版接口中显示已下架，无法播放，但在官网是可以正常播放的。

排查发现：

- 酷狗新版 `/song/url` 对该歌曲 hash 返回 `status: 3`，拿不到播放地址。
- 同一首歌通过酷狗旧移动端接口可以正常返回播放地址：
  - `https://m.kugou.com/app/i/getSongInfo.php?cmd=playInfo&hash=<HASH>`

## 修复方案

在酷狗播放源解析逻辑中增加兜底：

1. 先继续使用现有逻辑请求 `/song/url` 的所有音质和所有 hash 变体。
2. 如果全部失败，自动调用酷狗旧移动端接口。
3. 如果旧接口返回 `url` 或 `backup_url`，则使用该地址作为播放地址。
4. 云端歌曲不触发此兜底，避免影响云盘音源。
5. 兜底失败时保持原有不可播放行为，不影响其他歌曲。

## 修改文件

- `src/services/onlineMusic/kugouTransport.ts`
  - 新增 `requestKugouLegacyPlayInfo`
  - Electron 走主进程代理，Web 走 `/api/lyric-proxy`
- `src/services/onlineMusic/kugouProvider.ts`
  - `getAudioSource` 中新增旧接口兜底逻辑
- `test/unit/onlineMusic/kugouProvider.test.ts`
  - 新增 provider 层兜底测试
- `test/unit/onlineMusic/kugouTransport.test.ts`
  - 新增 transport 层旧接口请求测试

## 验证

已通过：

```bash
npm run typecheck
npx vitest run --config vitest.config.ts --pool=threads \
  test/unit/onlineMusic/kugouProvider.test.ts \
  test/unit/onlineMusic/kugouTransport.test.ts