### PR TITLE
fix(qq): 自建歌单加载为空，改走带凭据的路由

### DIFF
--- a/docs/qq-music-deployment.md
+++ b/docs/qq-music-deployment.md
@@ -293,6 +293,7 @@ GET /api/qq/getSongInfo/0039MnYb0qxYhV
 | Cloudflare 只有微信 | 检查 `QQ_QR_CHANNEL` binding、`QqQrChannel` 类名和 migration |
 | Cloudflare QQ 二维码打不开 | 确认依赖为 3.1.0 或更高版本，并检查 Worker 日志中的 WebSocket 错误 |
 | 正式 `workers.dev` 返回 1042，但 Preview 正常 | 等待新域名传播，不要因为这个现象修改 Static Assets 或 MQTT 代码 |
+| 自建歌单打不开，提示不是公开歌单 | 后端版本过旧，缺少带凭据的 `/user/playlist-detail` 路由；升级 `@yakult-green-tea/qq-music-api` 后即可读取不公开的自建歌单 |
 | 扫码后上游返回 `20279` | 先在 QQ 音乐账号中清理旧登录设备，再重新扫码 |
 | 修改 `VITE_QQ_API_BASE` 后仍请求旧地址 | 该变量在构建时写入前端，必须重新构建；同时检查 `.env.local` 是否覆盖平台配置 |
 | 关闭二维码后仍担心计费 | 查看日志是否出现取消请求，以及 Durable Object 的 `/open`、`/close` 是否成对出现 |

--- a/qq-diag.html
+++ b/qq-diag.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Folia QQ 歌单诊断</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        margin: 0;
+        padding: 16px;
+        background: #17181c;
+        color: #e8e8ea;
+        font: 14px/1.6 system-ui, -apple-system, "Segoe UI", "Noto Sans SC", sans-serif;
+      }
+      h1 { font-size: 17px; margin: 0 0 4px; }
+      .sub { color: #8b8d95; font-size: 12px; margin: 0 0 16px; }
+      .sub code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
+      .card {
+        border: 1px solid #2c2e35;
+        border-radius: 12px;
+        padding: 12px;
+        margin-bottom: 12px;
+        background: #1d1e23;
+      }
+      .card h2 { font-size: 13px; margin: 0 0 8px; color: #a9abb4; font-weight: 600; }
+      button {
+        appearance: none;
+        border: 1px solid #3a3d46;
+        background: #262830;
+        color: #e8e8ea;
+        border-radius: 9px;
+        padding: 9px 13px;
+        font-size: 13px;
+        cursor: pointer;
+        margin: 0 6px 6px 0;
+      }
+      button:active { background: #31343e; }
+      button:disabled { opacity: .45; cursor: default; }
+      button.primary { background: #2f5bd0; border-color: #3f6ae0; }
+      pre {
+        margin: 8px 0 0;
+        padding: 10px;
+        background: #121317;
+        border-radius: 8px;
+        font-size: 11.5px;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-all;
+        max-height: 340px;
+        overflow: auto;
+      }
+      .row {
+        border-top: 1px solid #2c2e35;
+        padding: 10px 0 4px;
+      }
+      .row:first-of-type { border-top: 0; }
+      .name { font-weight: 600; }
+      .meta { color: #8b8d95; font-size: 11.5px; word-break: break-all; }
+      .ok { color: #5fd68b; }
+      .bad { color: #ff7a7a; }
+      .warn { color: #f0c05a; }
+      .note { color: #8b8d95; font-size: 11.5px; margin-top: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>QQ 歌单诊断</h1>
+    <p class="sub">
+      只读探针，不会修改任何账号数据。请先在 Folia 主站登录 QQ 音乐，再打开本页。
+      与 <code>dev-probe.html</code> 一样，本页不在 <code>vite.config.ts</code> 的
+      <code>build.rollupOptions.input</code> 里，因此只在开发服务器上可用，不会进生产产物。
+    </p>
+    <div id="root"></div>
+    <script type="module" src="/test/manual/qq-diag/main.ts"></script>
+  </body>
+</html>

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -371,7 +371,7 @@ export const GridView: React.FC<GridViewProps> = ({
     // provider 侧的鉴权、协议或网络故障在界面上就完全不可见。
     // 存判别式而不是成品文案：翻译要在渲染时做，切换语言才能跟着变。
     const [loadError, setLoadError] = useState<
-        { kind: 'unsupported' } | { kind: 'generic'; message: string } | null
+        { kind: 'not-public' } | { kind: 'generic'; message: string } | null
     >(null);
     const [hasMore, setHasMore] = useState(true);
     const [offset, setOffset] = useState(0);
@@ -832,8 +832,8 @@ export const GridView: React.FC<GridViewProps> = ({
             }
         } catch (error) {
             console.error("GridView failed to load tracks:", error);
-            setLoadError(error instanceof OmniError && error.code === 'unsupported'
-                ? { kind: 'unsupported' }
+            setLoadError(error instanceof OmniError && error.code === 'not-public'
+                ? { kind: 'not-public' }
                 : { kind: 'generic', message: error instanceof Error ? error.message : String(error) });
         } finally {
             setLoading(false);
@@ -1949,8 +1949,8 @@ export const GridView: React.FC<GridViewProps> = ({
                 ) : gridItems.length === 0 ? (
                     <div className="max-w-md px-6 text-center text-sm font-sans opacity-40">
                         {loadError && !hasSearchQuery
-                            ? (loadError.kind === 'unsupported'
-                                ? t('playlist.loadUnsupported')
+                            ? (loadError.kind === 'not-public'
+                                ? t('playlist.loadNotPublic')
                                 : t('playlist.loadFailed', { error: loadError.message }))
                             : hasSearchQuery ? (t('home.gridSearchNoResults')) : (t('home.loadingLibrary'))}
                     </div>

--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -44,7 +44,7 @@ import { compareLocalFolderSongs, formatLocalAlbumTrackLabel, type LocalAlbumGro
 import { resolveGridViewContextTracks } from './folia-grid/gridViewContextActions';
 import { buildGridSurfaceState, runGridSurfaceAction, type GridSurfaceParams } from './folia-grid/gridSurfaceHandle';
 import { useGridSurfaceRegistration } from '../hooks/useGridSurfaceRegistration';
-import type { MediaId, ProviderCollection } from '../types/onlineMusic';
+import { OmniError, type MediaId, type ProviderCollection } from '../types/onlineMusic';
 import { useSidePanelBottomPx } from '../hooks/usePlayerBottomBarBottomPx';
 import { useGridViewSettingsStore } from '../stores/useGridViewSettingsStore';
 
@@ -367,6 +367,12 @@ export const GridView: React.FC<GridViewProps> = ({
     const [loading, setLoading] = useState(false);
     const [backgroundLoading, setBackgroundLoading] = useState(false);
     const [backgroundLoadFailed, setBackgroundLoadFailed] = useState(false);
+    // 在线集合加载失败必须和「集合确实是空的」分开显示：两者都渲染成空网格的话，
+    // provider 侧的鉴权、协议或网络故障在界面上就完全不可见。
+    // 存判别式而不是成品文案：翻译要在渲染时做，切换语言才能跟着变。
+    const [loadError, setLoadError] = useState<
+        { kind: 'unsupported' } | { kind: 'generic'; message: string } | null
+    >(null);
     const [hasMore, setHasMore] = useState(true);
     const [offset, setOffset] = useState(0);
     const [dailyRecommendationHistoryDates, setDailyRecommendationHistoryDates] = useState<string[]>([]);
@@ -729,6 +735,7 @@ export const GridView: React.FC<GridViewProps> = ({
     const loadTracks = async (reset = false) => {
         if (usesExternalTracks || !collection || collection.source !== 'online' || loading || (!hasMore && !reset)) return;
         setLoading(true);
+        if (reset) setLoadError(null);
 
         try {
             const currentOffset = reset ? 0 : offset;
@@ -825,6 +832,9 @@ export const GridView: React.FC<GridViewProps> = ({
             }
         } catch (error) {
             console.error("GridView failed to load tracks:", error);
+            setLoadError(error instanceof OmniError && error.code === 'unsupported'
+                ? { kind: 'unsupported' }
+                : { kind: 'generic', message: error instanceof Error ? error.message : String(error) });
         } finally {
             setLoading(false);
         }
@@ -1937,8 +1947,12 @@ export const GridView: React.FC<GridViewProps> = ({
                         <span className="text-sm font-semibold font-sans">{t('playlist.loading')}</span>
                     </div>
                 ) : gridItems.length === 0 ? (
-                    <div className="opacity-40 text-sm font-sans">
-                        {hasSearchQuery ? (t('home.gridSearchNoResults')) : (t('home.loadingLibrary'))}
+                    <div className="max-w-md px-6 text-center text-sm font-sans opacity-40">
+                        {loadError && !hasSearchQuery
+                            ? (loadError.kind === 'unsupported'
+                                ? t('playlist.loadUnsupported')
+                                : t('playlist.loadFailed', { error: loadError.message }))
+                            : hasSearchQuery ? (t('home.gridSearchNoResults')) : (t('home.loadingLibrary'))}
                     </div>
                 ) : (
                     <motion.div

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -783,7 +783,9 @@ export default {
     "loadMore": "Load More",
     "headerTitle": "Title",
     "headerTime": "Time",
-    "loading": "Loading"
+    "loading": "Loading",
+    "loadFailed": "Failed to load: {{error}}",
+    "loadUnsupported": "This playlist is not public, so the current music source cannot read its contents"
   },
   "search": {
     "placeholder": "Search songs...",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -785,7 +785,7 @@ export default {
     "headerTime": "Time",
     "loading": "Loading",
     "loadFailed": "Failed to load: {{error}}",
-    "loadUnsupported": "This playlist is not public, so the current music source cannot read its contents"
+    "loadNotPublic": "This playlist is not public, so the current music source cannot read its contents"
   },
   "search": {
     "placeholder": "Search songs...",

--- a/src/i18n/locales/in.ts
+++ b/src/i18n/locales/in.ts
@@ -782,7 +782,7 @@ export default {
     "headerTime": "Waktu",
     "loading": "Memuat",
     "loadFailed": "Gagal memuat: {{error}}",
-    "loadUnsupported": "Daftar putar ini tidak publik, sehingga sumber musik saat ini tidak dapat membaca isinya"
+    "loadNotPublic": "Daftar putar ini tidak publik, sehingga sumber musik saat ini tidak dapat membaca isinya"
   },
   "search": {
     "placeholder": "Cari lagu...",

--- a/src/i18n/locales/in.ts
+++ b/src/i18n/locales/in.ts
@@ -780,7 +780,9 @@ export default {
     "loadMore": "Muat Lebih Banyak",
     "headerTitle": "Judul",
     "headerTime": "Waktu",
-    "loading": "Memuat"
+    "loading": "Memuat",
+    "loadFailed": "Gagal memuat: {{error}}",
+    "loadUnsupported": "Daftar putar ini tidak publik, sehingga sumber musik saat ini tidak dapat membaca isinya"
   },
   "search": {
     "placeholder": "Cari lagu...",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -782,7 +782,9 @@ export default {
     "loadMore": "加载更多",
     "headerTitle": "标题",
     "headerTime": "时长",
-    "loading": "加载中"
+    "loading": "加载中",
+    "loadFailed": "加载失败：{{error}}",
+    "loadUnsupported": "这个歌单不是公开歌单，当前音源接口读不到它的内容"
   },
   "search": {
     "placeholder": "搜索歌曲...",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -784,7 +784,7 @@ export default {
     "headerTime": "时长",
     "loading": "加载中",
     "loadFailed": "加载失败：{{error}}",
-    "loadUnsupported": "这个歌单不是公开歌单，当前音源接口读不到它的内容"
+    "loadNotPublic": "这个歌单不是公开歌单，当前音源接口读不到它的内容"
   },
   "search": {
     "placeholder": "搜索歌曲...",

--- a/src/services/onlineMusic/qqNormalize.ts
+++ b/src/services/onlineMusic/qqNormalize.ts
@@ -296,6 +296,9 @@ export const normalizeQqCollection = (raw: unknown, type = 'playlist'): Provider
 
     const tid = pick(item, 'tid') ?? pick(existing, 'tid');
     const dirId = pick(item, 'dirId', 'dirid') ?? pick(existing, 'dirId');
+    // 可见性：1 公开、2 不公开（实测值）。匿名的 `/getSongListDetail` 读不到非公开歌单，
+    // 留着它才能把「歌单是空的」和「这条接口没资格读」分开。
+    const dirShow = pick(item, 'dirShow', 'dir_show') ?? pick(existing, 'dirShow');
     const rawId = pick(item, 'id');
     const dissid = pick(item, 'dissid')
         ?? pick(existing, 'dissid')
@@ -316,6 +319,7 @@ export const normalizeQqCollection = (raw: unknown, type = 'playlist'): Provider
             ['tid', tid],
             ['dirId', dirId],
             ['dissid', dissid],
+            ['dirShow', dirShow],
         ]),
     };
 };

--- a/src/services/onlineMusic/qqNormalize.ts
+++ b/src/services/onlineMusic/qqNormalize.ts
@@ -299,6 +299,11 @@ export const normalizeQqCollection = (raw: unknown, type = 'playlist'): Provider
     // 可见性：1 公开、2 不公开（实测值）。匿名的 `/getSongListDetail` 读不到非公开歌单，
     // 留着它才能把「歌单是空的」和「这条接口没资格读」分开。
     const dirShow = pick(item, 'dirShow', 'dir_show') ?? pick(existing, 'dirShow');
+    // 自建还是收藏。`/user/playlist` 把两类合在同一个数组里，而收藏的条目**也带 `dirId`** —— 那是创建者
+    // 账号里的目录号（实测收藏的他人歌单是 `dirId: 36`），所以不能拿 dirId 判断。自建条目来自
+    // GetPlaylistByUin，带 `dirName` / `songNum`；收藏条目是另一套字段（`name` / `songnum` / `orderTime` /
+    // `dirType`）。缓存回灌时沿用已经判过的结果。
+    const owned = pick(item, 'dirName') !== undefined ? true : pick(existing, 'owned');
     const rawId = pick(item, 'id');
     const dissid = pick(item, 'dissid')
         ?? pick(existing, 'dissid')
@@ -320,6 +325,7 @@ export const normalizeQqCollection = (raw: unknown, type = 'playlist'): Provider
             ['dirId', dirId],
             ['dissid', dissid],
             ['dirShow', dirShow],
+            ['owned', owned],
         ]),
     };
 };

--- a/src/services/onlineMusic/qqPlaylistDiagnostics.ts
+++ b/src/services/onlineMusic/qqPlaylistDiagnostics.ts
@@ -1,0 +1,192 @@
+import { OnlineProviderError, type ProviderCollection } from '../../types/onlineMusic';
+import { normalizeQqCollection } from './qqNormalize';
+import { qqProvider } from './qqProvider';
+import { hasQqSession, requestQq } from './qqTransport';
+
+// src/services/onlineMusic/qqPlaylistDiagnostics.ts
+
+/**
+ * 只读探针：把 QQ 歌单这条链路上的原始标识字段暴露出来，用于定位「自建歌单全部为空」。
+ *
+ * 放在 adapter 层是因为它必须看原始响应；返回的是稳定的探针类型，页面不接触 provider 字段名。
+ * 它不参与任何正常播放流程，UI 里也没有入口，只有 `/qq-diag.html` 手动打开时才会运行。
+ */
+
+/** 文档里作为示例的公开歌单，用作对照组：它能出歌就说明路由本身是通的。 */
+export const PUBLIC_PLAYLIST_CONTROL_ID = '7011264340';
+
+/** 正规化之后的集合本体，供探针把 provider 的真实入参一并带上。 */
+export interface QqPlaylistProbeEntry {
+    collection: ProviderCollection;
+    /** 正规化之后的集合 id —— 也就是 `getPlaylistTracks` 实际收到的那个值。 */
+    normalizedId: string;
+    name: string;
+    trackCount?: number;
+    /** 上游条目里与身份有关的原始字段，原样透出。 */
+    identity: Record<string, string | number | boolean | null>;
+    /** 上游这条记录的全部键名，用来确认 `dissid` 到底存不存在。 */
+    rawKeys: string[];
+}
+
+export interface QqPlaylistDetailProbe {
+    disstid: string;
+    /** 上游是否给出了歌单本体（`cdlist[0]`）。 */
+    ok: boolean;
+    code?: number;
+    subcode?: number;
+    message?: string;
+    cdlistLength?: number;
+    songlistLength?: number;
+    totalSongNum?: number;
+    dissName?: string;
+    /** 上游的可见性标志（`dir_show`）：1 公开、2 不公开（实测值）。匿名 CGI 读不读得到取决于它。 */
+    dirShow?: number;
+    /** 上游自己回声的 `disstid`，用来确认请求 id 被当成了什么。 */
+    echoedDisstid?: string;
+    /** 请求整体失败（网络、鉴权、上游拒收）时的说明。 */
+    error?: string;
+    /** songlist 第一条的键名与截断样本，用来核对它和 normalizeQqSong 的期待是否对得上。 */
+    sampleSongKeys?: string[];
+    sampleSong?: Record<string, unknown>;
+}
+
+/** 走完整 provider 链路（含 normalizeQqSong）的结果，用来把 transport 与 provider 分开定位。 */
+export interface QqPlaylistTracksProbe {
+    requestedId: string;
+    itemCount?: number;
+    total?: number;
+    hasMore?: boolean;
+    nextOffset?: number;
+    firstItem?: Record<string, unknown>;
+    error?: string;
+}
+
+const IDENTITY_KEYS = ['tid', 'dissid', 'dirId', 'dirid', 'id', 'dirShow', 'dirType', 'type'];
+
+const scalar = (value: unknown): string | number | boolean | null => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+    return JSON.stringify(value).slice(0, 120);
+};
+
+export const probeQqPlaylists = async (): Promise<QqPlaylistProbeEntry[]> => {
+    if (!hasQqSession()) throw new OnlineProviderError('auth-required', 'QQ 账号未登录', 'qq');
+
+    const response = await requestQq<any>('user_playlist', {});
+    const playlists = Array.isArray(response?.playlist) ? response.playlist : [];
+
+    return playlists.map((raw: any) => {
+        const item = raw && typeof raw === 'object' ? raw : {};
+        const normalized = normalizeQqCollection(item);
+        const identity: Record<string, string | number | boolean | null> = {};
+        IDENTITY_KEYS.forEach(key => {
+            if (item[key] !== undefined) identity[key] = scalar(item[key]);
+        });
+        return {
+            collection: normalized,
+            normalizedId: String(normalized.id ?? ''),
+            name: normalized.name,
+            ...(normalized.trackCount === undefined ? {} : { trackCount: normalized.trackCount }),
+            identity,
+            rawKeys: Object.keys(item).sort(),
+        };
+    });
+};
+
+/** songlist 首条的形状摘要。只取标识与显示字段，避免把整条上游响应搬进页面。 */
+const songSample = (raw: unknown): Pick<QqPlaylistDetailProbe, 'sampleSongKeys' | 'sampleSong'> => {
+    if (!raw || typeof raw !== 'object') return {};
+    const item = raw as Record<string, unknown>;
+    const sample: Record<string, unknown> = {};
+    ['id', 'mid', 'songid', 'songmid', 'name', 'title', 'songname', 'interval', 'album', 'singer', 'file']
+        .forEach(key => {
+            if (item[key] === undefined) return;
+            sample[key] = scalar(item[key]);
+        });
+    return { sampleSongKeys: Object.keys(item).sort(), sampleSong: sample };
+};
+
+/**
+ * 打一次匿名的歌单详情路由，并把上游状态码原样带回来。
+ *
+ * 这里刻意吞掉 `OnlineProviderError` 而不是让它冒泡：探针的价值就在于展示被拒收时的
+ * `code` / `subcode`，`cause` 里挂的正是被拒的那个节点。
+ */
+export const probeQqPlaylistDetail = async (disstid: string): Promise<QqPlaylistDetailProbe> => {
+    const id = String(disstid).trim();
+    try {
+        const response = await requestQq<any>('song_list_detail', { disstid: id });
+        const body = response?.response;
+        const cdlist = Array.isArray(body?.cdlist) ? body.cdlist : [];
+        const detail = cdlist[0];
+        const songlist = Array.isArray(detail?.songlist) ? detail.songlist : undefined;
+        const total = Number(detail?.total_song_num ?? detail?.songnum);
+        return {
+            disstid: id,
+            ok: Boolean(detail && typeof detail === 'object'),
+            code: Number(body?.code),
+            subcode: Number(body?.subcode),
+            ...(typeof body?.message === 'string' && body.message ? { message: body.message } : {}),
+            cdlistLength: cdlist.length,
+            ...(songlist === undefined ? {} : { songlistLength: songlist.length }),
+            ...(Number.isFinite(total) ? { totalSongNum: total } : {}),
+            ...(typeof detail?.dissname === 'string' ? { dissName: detail.dissname } : {}),
+            ...(Number.isFinite(Number(detail?.dir_show)) ? { dirShow: Number(detail.dir_show) } : {}),
+            ...(detail?.disstid === undefined ? {} : { echoedDisstid: String(detail.disstid) }),
+            ...songSample(songlist?.[0]),
+        };
+    } catch (error) {
+        const node = error instanceof OnlineProviderError ? error.cause as any : undefined;
+        return {
+            disstid: id,
+            ok: false,
+            ...(Number.isFinite(Number(node?.code)) ? { code: Number(node.code) } : {}),
+            ...(Number.isFinite(Number(node?.subcode)) ? { subcode: Number(node.subcode) } : {}),
+            ...(typeof node?.message === 'string' && node.message ? { message: node.message } : {}),
+            error: error instanceof Error ? error.message : String(error),
+        };
+    }
+};
+
+
+/**
+ * 走 `qqProvider.catalog.getPlaylistTracks`，也就是应用点开歌单时真正跑的那条路径。
+ *
+ * transport 能拿到 songlist 但界面是空的时候，答案只可能在这一段：要么 provider 自己返回了
+ * 空页，要么它返回了条目而问题在更上层。探针把两者分开。
+ */
+export const probeQqPlaylistTracks = async (
+    entry: QqPlaylistProbeEntry,
+    limit = 150,
+): Promise<QqPlaylistTracksProbe> => {
+    const requestedId = entry.normalizedId;
+    try {
+        const page = await qqProvider.catalog!.getPlaylistTracks!(
+            entry.collection.id,
+            limit,
+            0,
+            entry.collection,
+        );
+        const first = page.items[0];
+        return {
+            requestedId,
+            itemCount: page.items.length,
+            ...(page.total === undefined ? {} : { total: page.total }),
+            hasMore: page.hasMore,
+            nextOffset: page.nextOffset,
+            ...(first === undefined ? {} : {
+                firstItem: {
+                    id: first.id,
+                    name: first.name,
+                    qqMid: first.qqMid,
+                    durationMs: first.durationMs,
+                    artists: first.artists.map(artist => artist.name),
+                    albumName: first.album?.name,
+                    mediaId: first.sourceRef?.kind === 'online' ? first.sourceRef.mediaId : undefined,
+                },
+            }),
+        };
+    } catch (error) {
+        return { requestedId, error: error instanceof Error ? error.message : String(error) };
+    }
+};

--- a/src/services/onlineMusic/qqProvider.ts
+++ b/src/services/onlineMusic/qqProvider.ts
@@ -65,10 +65,10 @@ const getQqSongMid = (song: SongResult): string => {
  * 读一次歌单详情，并把「上游没读到这个歌单」和「歌单确实是空的」分开。
  *
  * 上游这条是匿名 CGI：歌单不公开时它**照样回 `code: 0`**，只是 `cdlist[0]` 退化成一个空壳 ——
- * 没有 `disstid`、没有 `dissname`，songlist 为空数组（实测 `dirShow: 2` 的自建歌单就是这样）。
- * 因此判据是回声的 `disstid` 在不在，而不是 `cdlist` 或 songlist 的长度：真的空歌单会带着
- * 完整的 `disstid` / `dissname` 回来。两者混成同一个空结果，就是用户看到的那个没有报错的
- * 「暂无内容」。
+ * 没有 `dissname`，songlist 为空数组。2026-09-11 用真实账号对一个 `dirShow: 2` 的自建歌单抓到的是
+ * `{ code: 0, disstid: '9777066643', dissname: undefined, songlist: [] }`：`disstid` 照样回声，
+ * 所以判据是 `dissname` 在不在，而不是 `disstid`，也不是 `cdlist` 或 songlist 的长度 —— 真的空歌单
+ * 会带着完整的 `dissname` 回来。两者混成同一个空结果，就是用户看到的那个没有报错的「暂无内容」。
  */
 const loadRawPlaylistTracks = async (
     id: MediaId,
@@ -77,16 +77,16 @@ const loadRawPlaylistTracks = async (
     const response = await requestQq<any>('song_list_detail', { disstid: String(id) });
     const cdlist = response?.response?.cdlist;
     const detail = Array.isArray(cdlist) ? cdlist[0] : undefined;
-    const echoedDisstid = String(detail?.disstid ?? '').trim();
+    const dissname = String(detail?.dissname ?? '').trim();
 
-    if (!detail || typeof detail !== 'object' || !echoedDisstid || echoedDisstid === '0') {
-        // 已知不公开时报 `unsupported` 而不是 `invalid-response`：这不是协议坏了，是这条匿名
-        // 路由没资格读它 —— 后端补上带凭据的歌单路由之后，这个状态就会消失。调用方据此给用户
-        // 一句能看懂的解释，而不是把协议细节甩到界面上。
+    if (!detail || typeof detail !== 'object' || !dissname) {
+        // 已知不公开时报 `not-public` 而不是 `invalid-response`：这不是协议坏了，是这条匿名
+        // 路由没资格读它 —— 后端补上带凭据的歌单路由之后，自建歌单就不会再走到这里。调用方据此
+        // 给用户一句能看懂的解释，而不是把协议细节甩到界面上。
         const dirShow = Number(collection?.providerData?.dirShow);
         const notPublic = Number.isFinite(dirShow) && dirShow !== 1;
         throw new OnlineProviderError(
-            notPublic ? 'unsupported' : 'invalid-response',
+            notPublic ? 'not-public' : 'invalid-response',
             `QQMusicApi song_list_detail could not read playlist ${String(id)}`
             + `${notPublic ? ' (not a public playlist; this anonymous endpoint cannot read it)' : ''}`,
             'qq',
@@ -167,6 +167,7 @@ const getPlaylistTracks = async (
     const safeLimit = Math.max(1, limit);
     const safeOffset = Math.max(0, offset);
     const dirId = Number(collection?.providerData?.dirId);
+    const owned = collection?.providerData?.owned === true;
 
     // 我喜欢留在它自己那条早就可用的路由上：换到新路由只会让一个本来就正常的功能去承担
     // 新后端的风险，而它要解决的问题（读不到不公开的自建歌单）在这里根本不存在。
@@ -182,23 +183,26 @@ const getPlaylistTracks = async (
         };
     }
 
-    // 其余自建歌单（有 dirId 就说明是用户自己的目录）优先走带凭据的路由：只有它读得到
-    // 不公开的歌单，而且支持真正的分页，不必像匿名路径那样每翻一页重拉整张歌单。
-    if (Number.isFinite(dirId) && dirId > 0) {
-        const owned = await loadRawOwnedPlaylistTracks(id, dirId, safeLimit, safeOffset);
-        if (owned) {
-            const items = owned.tracks.map(normalizeQqSong);
+    // 其余自建歌单优先走带凭据的路由：只有它读得到不公开的歌单，而且支持真正的分页，不必像匿名
+    // 路径那样每翻一页重拉整张歌单。判据是 `owned` 而不是 dirId —— 收藏的歌单也带 dirId，而带凭据的
+    // 路由读收藏歌单会少歌：实测一张 37 首的收藏歌单只回 36 首（缺一首付费歌），连 total 也跟着变成 36，
+    // 界面上完全看不出来。收藏歌单留在匿名路由上是完整的。
+    if (owned && Number.isFinite(dirId) && dirId > 0) {
+        const page = await loadRawOwnedPlaylistTracks(id, dirId, safeLimit, safeOffset);
+        if (page) {
+            const items = page.tracks.map(normalizeQqSong);
             const nextOffset = safeOffset + items.length;
             return {
                 items,
-                ...(owned.total === undefined ? {} : { total: owned.total }),
-                hasMore: owned.more || (owned.total !== undefined && nextOffset < owned.total),
+                ...(page.total === undefined ? {} : { total: page.total }),
+                // 空页必须停：上游的 total 可能比实际能读到的多（被过滤的歌），只看 total 会一直翻空页。
+                hasMore: items.length > 0 && (page.more || (page.total !== undefined && nextOffset < page.total)),
                 nextOffset,
             };
         }
     }
 
-    // 收藏的、分享链接进来的歌单没有 dirId，本来就只能走匿名路由；后端太旧时也回落到这里。
+    // 收藏的、分享链接进来的歌单本来就只能走匿名路由；后端太旧时也回落到这里。
     const { tracks, total } = await loadRawPlaylistTracks(id, collection);
     const items = tracks
         .slice(offset, offset + Math.max(0, limit))

--- a/src/services/onlineMusic/qqProvider.ts
+++ b/src/services/onlineMusic/qqProvider.ts
@@ -99,6 +99,51 @@ const loadRawPlaylistTracks = async (
     return { tracks, ...(Number.isFinite(total) && total >= 0 ? { total } : {}) };
 };
 
+// 后端有没有 `/user/playlist-detail` 只取决于它的版本，一个会话里不会变，所以探到一次 404
+// 就记下来，不再为每一页重试。刷新页面自然会重新探测。
+let ownedPlaylistRouteMissing = false;
+
+export const resetQqProviderRuntimeCache = (): void => {
+    ownedPlaylistRouteMissing = false;
+};
+
+/**
+ * 带凭据地读用户自己的歌单，响应形状与 `/user/liked-songs` 一致。
+ *
+ * 返回 `null` 表示这个后端没有这条路由（旧版本），调用方据此回落到匿名路径 —— 与
+ * `login_channels` 的处理方式相同：404 是「没有声明这个能力」，不是错误。其余失败照常抛出，
+ * 否则一次网络抖动会被误判成「后端不支持」并在整个会话里粘住。
+ */
+const loadRawOwnedPlaylistTracks = async (
+    tid: MediaId,
+    dirId: number,
+    limit: number,
+    offset: number,
+): Promise<{ tracks: unknown[]; total?: number; more: boolean } | null> => {
+    if (ownedPlaylistRouteMissing) return null;
+    try {
+        const response = await requestQq<any>('user_playlist_detail', {
+            tid: String(tid),
+            dirid: dirId,
+            offset,
+            limit,
+        });
+        const tracks = Array.isArray(response?.songs) ? response.songs : [];
+        const total = Number(response?.total);
+        return {
+            tracks,
+            ...(Number.isFinite(total) && total >= 0 ? { total } : {}),
+            more: response?.more === true,
+        };
+    } catch (error) {
+        if (error instanceof OnlineProviderError && error.code === 'unsupported') {
+            ownedPlaylistRouteMissing = true;
+            return null;
+        }
+        throw error;
+    }
+};
+
 const loadRawLikedTracks = async (
     limit: number,
     offset: number,
@@ -119,8 +164,14 @@ const getPlaylistTracks = async (
     offset: number,
     collection?: ProviderCollection,
 ): Promise<ProviderPage<ReturnType<typeof normalizeQqSong>>> => {
-    if (Number(collection?.providerData?.dirId) === 201) {
-        const { tracks, total, more } = await loadRawLikedTracks(Math.max(1, limit), Math.max(0, offset));
+    const safeLimit = Math.max(1, limit);
+    const safeOffset = Math.max(0, offset);
+    const dirId = Number(collection?.providerData?.dirId);
+
+    // 我喜欢留在它自己那条早就可用的路由上：换到新路由只会让一个本来就正常的功能去承担
+    // 新后端的风险，而它要解决的问题（读不到不公开的自建歌单）在这里根本不存在。
+    if (dirId === 201) {
+        const { tracks, total, more } = await loadRawLikedTracks(safeLimit, safeOffset);
         const items = tracks.map(normalizeQqSong);
         const nextOffset = offset + items.length;
         return {
@@ -130,6 +181,24 @@ const getPlaylistTracks = async (
             nextOffset,
         };
     }
+
+    // 其余自建歌单（有 dirId 就说明是用户自己的目录）优先走带凭据的路由：只有它读得到
+    // 不公开的歌单，而且支持真正的分页，不必像匿名路径那样每翻一页重拉整张歌单。
+    if (Number.isFinite(dirId) && dirId > 0) {
+        const owned = await loadRawOwnedPlaylistTracks(id, dirId, safeLimit, safeOffset);
+        if (owned) {
+            const items = owned.tracks.map(normalizeQqSong);
+            const nextOffset = safeOffset + items.length;
+            return {
+                items,
+                ...(owned.total === undefined ? {} : { total: owned.total }),
+                hasMore: owned.more || (owned.total !== undefined && nextOffset < owned.total),
+                nextOffset,
+            };
+        }
+    }
+
+    // 收藏的、分享链接进来的歌单没有 dirId，本来就只能走匿名路由；后端太旧时也回落到这里。
     const { tracks, total } = await loadRawPlaylistTracks(id, collection);
     const items = tracks
         .slice(offset, offset + Math.max(0, limit))

--- a/src/services/onlineMusic/qqProvider.ts
+++ b/src/services/onlineMusic/qqProvider.ts
@@ -61,11 +61,41 @@ const getQqSongMid = (song: SongResult): string => {
     return String(song.qqMid || sourceRef?.providerData?.songMid || sourceRef?.mediaId || '').trim();
 };
 
-const loadRawPlaylistTracks = async (id: MediaId): Promise<{ tracks: unknown[]; total?: number }> => {
+/**
+ * 读一次歌单详情，并把「上游没读到这个歌单」和「歌单确实是空的」分开。
+ *
+ * 上游这条是匿名 CGI：歌单不公开时它**照样回 `code: 0`**，只是 `cdlist[0]` 退化成一个空壳 ——
+ * 没有 `disstid`、没有 `dissname`，songlist 为空数组（实测 `dirShow: 2` 的自建歌单就是这样）。
+ * 因此判据是回声的 `disstid` 在不在，而不是 `cdlist` 或 songlist 的长度：真的空歌单会带着
+ * 完整的 `disstid` / `dissname` 回来。两者混成同一个空结果，就是用户看到的那个没有报错的
+ * 「暂无内容」。
+ */
+const loadRawPlaylistTracks = async (
+    id: MediaId,
+    collection?: ProviderCollection,
+): Promise<{ tracks: unknown[]; total?: number }> => {
     const response = await requestQq<any>('song_list_detail', { disstid: String(id) });
-    const detail = Array.isArray(response?.response?.cdlist) ? response.response.cdlist[0] : undefined;
-    const tracks = Array.isArray(detail?.songlist) ? detail.songlist : [];
-    const total = Number(detail?.total_song_num ?? detail?.songnum);
+    const cdlist = response?.response?.cdlist;
+    const detail = Array.isArray(cdlist) ? cdlist[0] : undefined;
+    const echoedDisstid = String(detail?.disstid ?? '').trim();
+
+    if (!detail || typeof detail !== 'object' || !echoedDisstid || echoedDisstid === '0') {
+        // 已知不公开时报 `unsupported` 而不是 `invalid-response`：这不是协议坏了，是这条匿名
+        // 路由没资格读它 —— 后端补上带凭据的歌单路由之后，这个状态就会消失。调用方据此给用户
+        // 一句能看懂的解释，而不是把协议细节甩到界面上。
+        const dirShow = Number(collection?.providerData?.dirShow);
+        const notPublic = Number.isFinite(dirShow) && dirShow !== 1;
+        throw new OnlineProviderError(
+            notPublic ? 'unsupported' : 'invalid-response',
+            `QQMusicApi song_list_detail could not read playlist ${String(id)}`
+            + `${notPublic ? ' (not a public playlist; this anonymous endpoint cannot read it)' : ''}`,
+            'qq',
+            response?.response,
+        );
+    }
+
+    const tracks = Array.isArray(detail.songlist) ? detail.songlist : [];
+    const total = Number(detail.total_song_num ?? detail.songnum);
     return { tracks, ...(Number.isFinite(total) && total >= 0 ? { total } : {}) };
 };
 
@@ -100,7 +130,7 @@ const getPlaylistTracks = async (
             nextOffset,
         };
     }
-    const { tracks, total } = await loadRawPlaylistTracks(id);
+    const { tracks, total } = await loadRawPlaylistTracks(id, collection);
     const items = tracks
         .slice(offset, offset + Math.max(0, limit))
         .map(normalizeQqSong);

--- a/src/services/onlineMusic/qqTransport.ts
+++ b/src/services/onlineMusic/qqTransport.ts
@@ -123,6 +123,9 @@ const readJsonBody = async (response: Response): Promise<any> => {
 // 登录与播放路由用的是另一套码值（如 `login_status` 回 200），故不纳入此检查。
 const CATALOG_STATUS_NODES: Partial<Record<QqOperation, string[][]>> = {
     album_info: [['response']],
+    // 歌单详情的上游是匿名 CGI：歌单不存在、不公开或参数不被接受时它照样回 HTTP 200，
+    // 差别只在这个 `code` 上。不登记的话拒绝会一路变成空歌单，UI 只剩「暂无内容」。
+    song_list_detail: [['response']],
     artist_songs: [['response'], ['response', 'singer']],
     artist_albums: [['response'], ['response', 'singer']],
 };

--- a/src/services/onlineMusic/qqTransport.ts
+++ b/src/services/onlineMusic/qqTransport.ts
@@ -6,7 +6,8 @@ import { readProviderSessionValue, removeProviderSessionValue, writeProviderSess
 export const QQ_OPERATIONS = [
     'login_qr_key', 'login_qr_create', 'login_qr_check', 'login_qr_cancel', 'login_status', 'logout',
     'login_channels',
-    'user_detail', 'user_playlist', 'user_albums', 'user_liked_songs', 'music_play', 'song_list_detail', 'song_info',
+    'user_detail', 'user_playlist', 'user_albums', 'user_liked_songs', 'user_playlist_detail',
+    'music_play', 'song_list_detail', 'song_info',
     'album_info', 'artist_albums', 'artist_songs',
 ] as const;
 
@@ -26,6 +27,9 @@ const ENDPOINTS: Record<QqOperation, string> = {
     user_playlist: '/user/playlist',
     user_albums: '/user/albums',
     user_liked_songs: '/user/liked-songs',
+    // 带凭据地读登录用户自己的歌单。匿名的 `song_list_detail` 读不了不公开的歌单，这条可以。
+    // 与 `login_channels` 同样的处境：旧后端没有这条路由，回 404，调用方要当成「没有声明」。
+    user_playlist_detail: '/user/playlist-detail',
     music_play: '/getMusicPlay',
     song_list_detail: '/getSongListDetail',
     song_info: '/getSongInfo',
@@ -233,6 +237,17 @@ export const requestQq = async <T = unknown>(operation: QqOperation, params: QqP
         if (response.status === 401) {
             clearQqSession();
             throw new OnlineProviderError('auth-required', 'QQMusicApi login required', 'qq', failure);
+        }
+        // 404 是「这个后端没有这条路由」，不是网络故障 —— 用户可以自行部署任意版本的后端，
+        // 新路由在旧后端上必然 404。报成 `unsupported`，调用方才能据此回落到旧路径，
+        // 而不必去解析错误文案里的状态码。
+        if (response.status === 404) {
+            throw new OnlineProviderError(
+                'unsupported',
+                `QQMusicApi has no ${operation} route`,
+                'qq',
+                failure,
+            );
         }
         throw new OnlineProviderError('network', `QQMusicApi request failed: ${response.status}`, 'qq', failure);
     }

--- a/src/types/onlineMusic.ts
+++ b/src/types/onlineMusic.ts
@@ -183,6 +183,9 @@ export type QrLoginState =
 export type ProviderErrorCode =
     | 'auth-required'
     | 'unsupported'
+    // 集合设为不公开，当前这条读取路径没资格读它。与 `unsupported`（这个后端或 provider 没有这项能力）
+    // 分开，界面才能只在这种情况下给出「不是公开歌单」的解释。
+    | 'not-public'
     | 'unavailable'
     | 'not-playable'
     | 'network'

--- a/test/manual/qq-diag/main.ts
+++ b/test/manual/qq-diag/main.ts
@@ -1,0 +1,207 @@
+import {
+    PUBLIC_PLAYLIST_CONTROL_ID,
+    probeQqPlaylistDetail,
+    probeQqPlaylists,
+    type QqPlaylistDetailProbe,
+    type QqPlaylistProbeEntry,
+} from '../../../src/services/onlineMusic/qqPlaylistDiagnostics';
+
+// test/manual/qq-diag/main.ts
+
+/**
+ * 手动诊断台：定位「QQ 自建歌单全部加载为空」。
+ *
+ * 之所以做成独立页面而不是主应用里的面板：需要看的是原始标识字段和上游状态码，正常 UI 刻意
+ * 把这些都正规化掉了；而且这条链路坏掉时主应用恰好什么都不显示，没有可依附的入口。
+ */
+
+const root = document.getElementById('root')!;
+const collected: Record<string, unknown> = {};
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    className?: string,
+    text?: string,
+): HTMLElementTagNameMap[K] => {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+};
+
+const card = (title: string): HTMLDivElement => {
+    const box = el('div', 'card');
+    box.appendChild(el('h2', undefined, title));
+    root.appendChild(box);
+    return box;
+};
+
+const dump = (parent: HTMLElement, value: unknown): HTMLPreElement => {
+    const pre = el('pre', undefined, JSON.stringify(value, null, 2));
+    parent.appendChild(pre);
+    return pre;
+};
+
+const errorText = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+/** 把一次详情探测渲染成一行结论，避免用户自己读 JSON 判断成败。 */
+const verdict = (probe: QqPlaylistDetailProbe): { text: string; className: string } => {
+    if (probe.error && !probe.ok) return { text: `请求失败：${probe.error}`, className: 'bad' };
+    if (!probe.ok) return { text: '上游没有返回歌单本体（cdlist 为空）', className: 'bad' };
+    // 🔴 只有 1 是公开：不公开实测是 2，truthy 判断会把它显示成公开。
+    const visibility = probe.dirShow === undefined ? '' : `（dir_show=${probe.dirShow}${probe.dirShow === 1 ? ' 公开' : ' 不公开'}）`;
+    if (probe.songlistLength === 0) {
+        return { text: `返回了歌单，但 songlist 是空的${visibility}`, className: 'warn' };
+    }
+    return { text: `返回 ${probe.songlistLength} 首${visibility}`, className: 'ok' };
+};
+
+const renderDetail = (parent: HTMLElement, probe: QqPlaylistDetailProbe): void => {
+    const line = verdict(probe);
+    parent.appendChild(el('div', `meta ${line.className}`, `→ ${line.text}`));
+    dump(parent, probe);
+};
+
+const sessionCard = (): void => {
+    const box = card('1. 会话');
+    const hasToken = Boolean(localStorage.getItem('online_provider:qq:cookie'));
+    box.appendChild(el(
+        'div',
+        `meta ${hasToken ? 'ok' : 'bad'}`,
+        hasToken ? '已检测到 QQ 登录态' : '没有登录态：请先回主站登录 QQ 音乐，再刷新本页',
+    ));
+};
+
+const playlistCard = (): void => {
+    const box = card('2. 歌单列表（带鉴权）');
+    const run = el('button', 'primary', '读取我的歌单');
+    box.appendChild(run);
+    const output = el('div');
+    box.appendChild(output);
+
+    run.onclick = async () => {
+        run.disabled = true;
+        output.replaceChildren();
+        try {
+            const entries = await probeQqPlaylists();
+            collected.playlists = entries;
+            output.appendChild(el('div', 'meta', `共 ${entries.length} 个集合。`));
+            entries.forEach(entry => output.appendChild(playlistRow(entry)));
+        } catch (error) {
+            output.appendChild(el('div', 'meta bad', errorText(error)));
+        } finally {
+            run.disabled = false;
+        }
+    };
+};
+
+const playlistRow = (entry: QqPlaylistProbeEntry): HTMLElement => {
+    const row = el('div', 'row');
+    row.appendChild(el('div', 'name', entry.name || '(无名)'));
+    row.appendChild(el(
+        'div',
+        'meta',
+        `归一化 id=${entry.normalizedId}`
+        + `${entry.trackCount === undefined ? '' : ` · 卡片显示 ${entry.trackCount} 首`}`,
+    ));
+    row.appendChild(el('div', 'meta', `身份字段 ${JSON.stringify(entry.identity)}`));
+    row.appendChild(el('div', 'meta', `上游键名 ${entry.rawKeys.join(', ')}`));
+
+    const test = el('button', undefined, '测这个歌单的详情');
+    row.appendChild(test);
+    const output = el('div');
+    row.appendChild(output);
+
+    test.onclick = async () => {
+        test.disabled = true;
+        output.replaceChildren();
+        const probe = await probeQqPlaylistDetail(entry.normalizedId);
+        const key = `detail:${entry.name || entry.normalizedId}`;
+        collected[key] = probe;
+        renderDetail(output, probe);
+        test.disabled = false;
+    };
+    return row;
+};
+
+const controlCard = (): void => {
+    const box = card('3. 对照组：一个公开歌单（匿名路由）');
+    box.appendChild(el(
+        'div',
+        'meta',
+        `用 disstid=${PUBLIC_PLAYLIST_CONTROL_ID} 打同一条路由。它出歌、自建歌单不出歌，`
+        + '就说明路由本身是通的，问题在歌单可见性或 id 语义上。',
+    ));
+    const run = el('button', undefined, '跑对照组');
+    box.appendChild(run);
+    const output = el('div');
+    box.appendChild(output);
+
+    run.onclick = async () => {
+        run.disabled = true;
+        output.replaceChildren();
+        const probe = await probeQqPlaylistDetail(PUBLIC_PLAYLIST_CONTROL_ID);
+        collected.publicControl = probe;
+        renderDetail(output, probe);
+        run.disabled = false;
+    };
+};
+
+const manualCard = (): void => {
+    const box = card('4. 手动测任意 disstid');
+    const input = el('input') as HTMLInputElement;
+    input.placeholder = '输入 disstid / tid';
+    input.style.cssText = 'width:100%;box-sizing:border-box;padding:9px 11px;border-radius:9px;'
+        + 'border:1px solid #3a3d46;background:#121317;color:#e8e8ea;font-size:13px;margin-bottom:8px;';
+    box.appendChild(input);
+    const run = el('button', undefined, '测这个 id');
+    box.appendChild(run);
+    const output = el('div');
+    box.appendChild(output);
+
+    run.onclick = async () => {
+        const value = input.value.trim();
+        if (!value) return;
+        run.disabled = true;
+        output.replaceChildren();
+        const probe = await probeQqPlaylistDetail(value);
+        collected[`manual:${value}`] = probe;
+        renderDetail(output, probe);
+        run.disabled = false;
+    };
+};
+
+const exportCard = (): void => {
+    const box = card('5. 导出结果');
+    box.appendChild(el('div', 'meta', '把上面跑过的结果一次性复制出来，贴回对话即可。'));
+    const copy = el('button', 'primary', '复制全部结果');
+    box.appendChild(copy);
+    const output = el('div');
+    box.appendChild(output);
+
+    copy.onclick = async () => {
+        const text = JSON.stringify(collected, null, 2);
+        try {
+            await navigator.clipboard.writeText(text);
+            output.replaceChildren(el('div', 'meta ok', '已复制到剪贴板。'));
+        } catch {
+            // 移动端浏览器在非安全上下文或无用户手势时会拒绝写剪贴板，退回成可长按选中的文本。
+            output.replaceChildren(el('div', 'meta warn', '剪贴板不可用，请长按下面的文本手动复制：'));
+            dump(output, collected);
+        }
+    };
+};
+
+sessionCard();
+playlistCard();
+controlCard();
+manualCard();
+exportCard();
+
+root.appendChild(el(
+    'div',
+    'note',
+    '判读：第 2 步里自建歌单的「上游键名」有没有 dissid，决定了 id 取值是不是选错；'
+    + '第 3 步对照组能出歌而自建歌单不出，指向匿名路由读不了非公开歌单。'
+    + '把自建歌单在 QQ 音乐 App 里改成公开后重测第 2 步，是区分这两者的决定性实验。',
+));

--- a/test/unit/onlineMusic/qqProvider.test.ts
+++ b/test/unit/onlineMusic/qqProvider.test.ts
@@ -555,7 +555,8 @@ describe('qqProvider', () => {
     it('loads regular playlists normally but uses the encrypted-UIN endpoint for liked songs', async () => {
         requestMock
             .mockResolvedValueOnce({
-                response: { cdlist: [{ songnum: 1, total_song_num: 1, songlist: [SEARCH_ITEM] }] },
+                // 上游成功时一定回声 `disstid`；不公开歌单给的空壳正是少了它。
+                response: { cdlist: [{ disstid: '7', songnum: 1, total_song_num: 1, songlist: [SEARCH_ITEM] }] },
             })
             .mockResolvedValue({ code: 200, songs: [SEARCH_ITEM], total: 1, more: false });
 
@@ -577,6 +578,40 @@ describe('qqProvider', () => {
             ['user_liked_songs', { offset: 0, limit: 100 }],
             ['user_liked_songs', { offset: 0, limit: 50 }],
         ]);
+    });
+
+    // 「歌单读不到」和「歌单是空的」必须分开，判据是回声的 `disstid` 在不在。
+    it('fails loudly when the playlist detail carries no cdlist entry', async () => {
+        requestMock.mockResolvedValue({ response: { code: 0, cdlist: [] } });
+
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0)).rejects.toMatchObject({
+            code: 'invalid-response',
+            message: expect.stringContaining('7'),
+        });
+    });
+
+    // 🔴 不公开的自建歌单：上游回 `code: 0` 加一个没有 disstid 的空壳，长度判断完全看不出问题。
+    it('fails loudly on the stub a non-public playlist answers with', async () => {
+        requestMock.mockResolvedValue({ response: { code: 0, cdlist: [{ songlist: [] }] } });
+        const collection = normalizeQqCollection({ tid: 7, dirId: 1, dirName: '私密歌单', dirShow: 2 });
+
+        // `unsupported` 而不是 `invalid-response`：协议没坏，是这条路由没资格读它。
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0, collection)).rejects.toMatchObject({
+            code: 'unsupported',
+            message: expect.stringContaining('not a public playlist'),
+        });
+    });
+
+    it('still reports a genuinely empty playlist as an empty page', async () => {
+        requestMock.mockResolvedValue({
+            response: { code: 0, cdlist: [{ disstid: '7', dissname: '空歌单', songnum: 0, songlist: [] }] },
+        });
+
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0)).resolves.toMatchObject({
+            items: [],
+            total: 0,
+            hasMore: false,
+        });
     });
 
     it('normalizes album and artist collections onto mid identity and derives the cover from it', () => {

--- a/test/unit/onlineMusic/qqProvider.test.ts
+++ b/test/unit/onlineMusic/qqProvider.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/utils/lyrics/providers/qqLyricProvider', () => ({
     fetchQQLyrics: fetchQQLyricsMock,
 }));
 
-import { qqProvider } from '@/services/onlineMusic/qqProvider';
+import { qqProvider, resetQqProviderRuntimeCache } from '@/services/onlineMusic/qqProvider';
 import { normalizeQqCollection, normalizeQqSong, normalizeQqUser } from '@/services/onlineMusic/qqNormalize';
 import { OnlineProviderError } from '@/types/onlineMusic';
 
@@ -162,6 +162,7 @@ describe('qqProvider', () => {
         searchQQLyricsMock.mockReset();
         fetchQQLyricsMock.mockReset();
         transportState.hasSession = true;
+        resetQqProviderRuntimeCache();
     });
 
     it('declares readable library features without exposing unsupported mutations or recommendations', () => {
@@ -590,9 +591,12 @@ describe('qqProvider', () => {
         });
     });
 
-    // 🔴 不公开的自建歌单：上游回 `code: 0` 加一个没有 disstid 的空壳，长度判断完全看不出问题。
+    // 🔴 旧后端 + 不公开的自建歌单，也就是这个 bug 被报上来时的处境：没有带凭据的路由可用，
+    // 匿名 CGI 回 `code: 0` 加一个没有 disstid 的空壳，按长度判断完全看不出问题。
     it('fails loudly on the stub a non-public playlist answers with', async () => {
-        requestMock.mockResolvedValue({ response: { code: 0, cdlist: [{ songlist: [] }] } });
+        requestMock
+            .mockRejectedValueOnce(new OnlineProviderError('unsupported', 'QQMusicApi has no route', 'qq'))
+            .mockResolvedValue({ response: { code: 0, cdlist: [{ songlist: [] }] } });
         const collection = normalizeQqCollection({ tid: 7, dirId: 1, dirName: '私密歌单', dirShow: 2 });
 
         // `unsupported` 而不是 `invalid-response`：协议没坏，是这条路由没资格读它。
@@ -612,6 +616,55 @@ describe('qqProvider', () => {
             total: 0,
             hasMore: false,
         });
+    });
+
+    // 自建歌单只有带凭据的路由读得到（匿名 CGI 对不公开歌单回空壳），且它支持真正的分页。
+    it('reads an owned playlist through the authenticated route and forwards the real page window', async () => {
+        requestMock.mockResolvedValue({ code: 200, songs: [SEARCH_ITEM], total: 8, more: true });
+        const collection = normalizeQqCollection({ tid: 7, dirId: 2, dirName: '新建歌单', dirShow: 2 });
+
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 100, collection)).resolves.toMatchObject({
+            total: 8,
+            hasMore: true,
+            nextOffset: 101,
+            items: [expect.objectContaining({ qqMid: '003rJSwm3TechU' })],
+        });
+        expect(requestMock).toHaveBeenCalledWith(
+            'user_playlist_detail',
+            { tid: '7', dirid: 2, offset: 100, limit: 50 },
+        );
+    });
+
+    // 用户可以自行部署任意版本的后端，新路由在旧后端上必然 404。
+    it('falls back to the anonymous route when the backend has no authenticated playlist route', async () => {
+        requestMock
+            .mockRejectedValueOnce(new OnlineProviderError('unsupported', 'QQMusicApi has no route', 'qq'))
+            .mockResolvedValue({
+                response: { code: 0, cdlist: [{ disstid: '7', total_song_num: 1, songlist: [SEARCH_ITEM] }] },
+            });
+        const collection = normalizeQqCollection({ tid: 7, dirId: 2, dirName: '新建歌单' });
+
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0, collection)).resolves.toMatchObject({
+            total: 1,
+            items: [expect.objectContaining({ qqMid: '003rJSwm3TechU' })],
+        });
+        expect(requestMock.mock.calls.map(call => call[0]))
+            .toEqual(['user_playlist_detail', 'song_list_detail']);
+
+        // 探到一次 404 就记住，后续页不再重试新路由。
+        requestMock.mockClear();
+        await qqProvider.catalog!.getPlaylistTracks!(7, 50, 0, collection);
+        expect(requestMock.mock.calls.map(call => call[0])).toEqual(['song_list_detail']);
+    });
+
+    // 网络抖动不能被当成「后端不支持」，否则整个会话都会粘在匿名路径上。
+    it('does not treat a transient failure as a missing route', async () => {
+        requestMock.mockRejectedValue(new OnlineProviderError('network', 'QQMusicApi request failed: 502', 'qq'));
+        const collection = normalizeQqCollection({ tid: 7, dirId: 2, dirName: '新建歌单' });
+
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0, collection))
+            .rejects.toMatchObject({ code: 'network' });
+        expect(requestMock.mock.calls.map(call => call[0])).toEqual(['user_playlist_detail']);
     });
 
     it('normalizes album and artist collections onto mid identity and derives the cover from it', () => {

--- a/test/unit/onlineMusic/qqProvider.test.ts
+++ b/test/unit/onlineMusic/qqProvider.test.ts
@@ -276,7 +276,7 @@ describe('qqProvider', () => {
             type: 'playlist',
             coverUrl: 'https://img.example.test/big.jpg',
             trackCount: 2,
-            providerData: { tid: 7, dirId: 201 },
+            providerData: { tid: 7, dirId: 201, owned: true },
         });
         expect(normalizeQqCollection(normalizeQqCollection(PLAYLIST_ITEM))).toEqual(normalizeQqCollection(PLAYLIST_ITEM));
         expect(normalizeQqCollection({ id: 8, title: '收藏歌单', picurl: 'https://img.example.test/fav.jpg', songnum: 3 })).toEqual({
@@ -556,8 +556,8 @@ describe('qqProvider', () => {
     it('loads regular playlists normally but uses the encrypted-UIN endpoint for liked songs', async () => {
         requestMock
             .mockResolvedValueOnce({
-                // 上游成功时一定回声 `disstid`；不公开歌单给的空壳正是少了它。
-                response: { cdlist: [{ disstid: '7', songnum: 1, total_song_num: 1, songlist: [SEARCH_ITEM] }] },
+                // 上游成功时一定带 `dissname`；不公开歌单给的空壳正是少了它（`disstid` 两种情况都会回声）。
+                response: { cdlist: [{ disstid: '7', dissname: '公开歌单', songnum: 1, total_song_num: 1, songlist: [SEARCH_ITEM] }] },
             })
             .mockResolvedValue({ code: 200, songs: [SEARCH_ITEM], total: 1, more: false });
 
@@ -581,7 +581,7 @@ describe('qqProvider', () => {
         ]);
     });
 
-    // 「歌单读不到」和「歌单是空的」必须分开，判据是回声的 `disstid` 在不在。
+    // 「歌单读不到」和「歌单是空的」必须分开，判据是 `dissname` 在不在。
     it('fails loudly when the playlist detail carries no cdlist entry', async () => {
         requestMock.mockResolvedValue({ response: { code: 0, cdlist: [] } });
 
@@ -592,16 +592,17 @@ describe('qqProvider', () => {
     });
 
     // 🔴 旧后端 + 不公开的自建歌单，也就是这个 bug 被报上来时的处境：没有带凭据的路由可用，
-    // 匿名 CGI 回 `code: 0` 加一个没有 disstid 的空壳，按长度判断完全看不出问题。
+    // 匿名 CGI 回 `code: 0` 加一个空壳，按长度判断完全看不出问题。空壳是 2026-09-11 用真实账号抓的：
+    // `disstid` 照样回声，缺的是 `dissname`。
     it('fails loudly on the stub a non-public playlist answers with', async () => {
         requestMock
             .mockRejectedValueOnce(new OnlineProviderError('unsupported', 'QQMusicApi has no route', 'qq'))
-            .mockResolvedValue({ response: { code: 0, cdlist: [{ songlist: [] }] } });
-        const collection = normalizeQqCollection({ tid: 7, dirId: 1, dirName: '私密歌单', dirShow: 2 });
+            .mockResolvedValue({ response: { code: 0, cdlist: [{ disstid: '9777066643', songlist: [] }] } });
+        const collection = normalizeQqCollection({ tid: 9777066643, dirId: 1, dirName: '新建歌单1', songNum: 3, dirShow: 2 });
 
-        // `unsupported` 而不是 `invalid-response`：协议没坏，是这条路由没资格读它。
-        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0, collection)).rejects.toMatchObject({
-            code: 'unsupported',
+        // `not-public` 而不是 `invalid-response`：协议没坏，是这条路由没资格读它。
+        await expect(qqProvider.catalog!.getPlaylistTracks!(9777066643, 50, 0, collection)).rejects.toMatchObject({
+            code: 'not-public',
             message: expect.stringContaining('not a public playlist'),
         });
     });
@@ -640,7 +641,7 @@ describe('qqProvider', () => {
         requestMock
             .mockRejectedValueOnce(new OnlineProviderError('unsupported', 'QQMusicApi has no route', 'qq'))
             .mockResolvedValue({
-                response: { code: 0, cdlist: [{ disstid: '7', total_song_num: 1, songlist: [SEARCH_ITEM] }] },
+                response: { code: 0, cdlist: [{ disstid: '7', dissname: '新建歌单', total_song_num: 1, songlist: [SEARCH_ITEM] }] },
             });
         const collection = normalizeQqCollection({ tid: 7, dirId: 2, dirName: '新建歌单' });
 
@@ -665,6 +666,46 @@ describe('qqProvider', () => {
         await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0, collection))
             .rejects.toMatchObject({ code: 'network' });
         expect(requestMock.mock.calls.map(call => call[0])).toEqual(['user_playlist_detail']);
+    });
+
+    // 🔴 收藏的他人歌单在 `/user/playlist` 里也带 `dirId`（创建者账号里的目录号），字段形状取自
+    // 2026-09-11 的真实账号。带凭据的路由读它会少歌：37 首只回 36 首，total 也变成 36。
+    it('keeps a favourited playlist on the anonymous route even though it carries a dirId', async () => {
+        requestMock.mockResolvedValue({
+            response: { code: 0, cdlist: [{ disstid: '7009600126', dissname: '毕业季：不为青春画句号', total_song_num: 37, songlist: [SEARCH_ITEM] }] },
+        });
+        const favourite = normalizeQqCollection({
+            tid: 7009600126, dirId: 36, name: '毕业季：不为青春画句号', songnum: 37, dirShow: 1, orderTime: 1789128000, dirType: 0,
+        });
+
+        expect(favourite.providerData).not.toHaveProperty('owned');
+        await qqProvider.catalog!.getPlaylistTracks!(7009600126, 50, 0, favourite);
+        expect(requestMock.mock.calls.map(call => call[0])).toEqual(['song_list_detail']);
+    });
+
+    it('remembers that a playlist is owned when the cached collection is normalized again', () => {
+        const owned = normalizeQqCollection({ tid: 7, dirId: 2, dirName: '新建歌单', songNum: 3 });
+        expect(normalizeQqCollection(owned).providerData).toMatchObject({ tid: 7, dirId: 2, owned: true });
+    });
+
+    // 上游的 total 可能比实际读得到的多（被过滤掉的歌）：只看 total 的话会一直翻空页。
+    it('stops paging an owned playlist on an empty page even when the total promises more', async () => {
+        requestMock.mockResolvedValue({ code: 200, songs: [], total: 37, more: false });
+        const collection = normalizeQqCollection({ tid: 7, dirId: 2, dirName: '新建歌单' });
+
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 36, collection)).resolves.toMatchObject({
+            items: [],
+            hasMore: false,
+            nextOffset: 36,
+        });
+    });
+
+    // 404 只说明后端没有这条路由，不说明歌单不公开：「不是公开歌单」这句解释只能留给真正的空壳。
+    it('does not blame playlist visibility for a missing anonymous route', async () => {
+        requestMock.mockRejectedValue(new OnlineProviderError('unsupported', 'QQMusicApi has no song_list_detail route', 'qq'));
+        const favourite = normalizeQqCollection({ tid: 7, dirId: 36, name: '收藏', dirShow: 2 });
+
+        await expect(qqProvider.catalog!.getPlaylistTracks!(7, 50, 0, favourite)).rejects.toMatchObject({ code: 'unsupported' });
     });
 
     it('normalizes album and artist collections onto mid identity and derives the cover from it', () => {

--- a/test/unit/onlineMusic/qqTransport.test.ts
+++ b/test/unit/onlineMusic/qqTransport.test.ts
@@ -280,6 +280,19 @@ describe('QQ Music Web transport', () => {
         await expect(requestQq('artist_songs', { singermid: '0025NhlN2yWrP4' })).resolves.toEqual(body);
     });
 
+    // 歌单详情的上游是匿名 CGI，被拒收时同样只在响应体里给码；不检查就会退化成一个空歌单。
+    it('surfaces an upstream rejection on the playlist detail route', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockImplementation(async () => Response.json({
+            response: { code: 3, subcode: 3, message: 'no such diss', cdlist: [] },
+        })));
+        const { requestQq } = await import('@/services/onlineMusic/qqTransport');
+
+        await expect(requestQq('song_list_detail', { disstid: '7' })).rejects.toMatchObject({
+            code: 'invalid-response',
+            message: expect.stringContaining('code 3'),
+        });
+    });
+
     // 登录路由用的是另一套码值（`login_status` 正常就回 200），不能被曲库那条规则误伤。
     it('leaves non-catalog operations out of the upstream status check', async () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ code: 200, data: {} })));

--- a/test/unit/onlineMusic/qqTransport.test.ts
+++ b/test/unit/onlineMusic/qqTransport.test.ts
@@ -375,6 +375,17 @@ describe('QQ Music Web transport', () => {
         });
     });
 
+    // 旧后端没有新加的路由，回 404。那是「没有声明这个能力」，调用方要能回落而不是报网络错。
+    it('maps a missing route to unsupported rather than a network failure', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json({ error: 'Not Found' }, { status: 404 })));
+        const { requestQq } = await import('@/services/onlineMusic/qqTransport');
+
+        await expect(requestQq('user_playlist_detail', { tid: '7', dirid: 2 })).rejects.toMatchObject({
+            code: 'unsupported',
+            providerId: 'qq',
+        });
+    });
+
     it('maps an unreadable body to invalid-response', async () => {
         const fetchMock = vi.fn().mockResolvedValue(new Response('<html>bad gateway</html>', { status: 200 }));
         vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
## 前后端对接与更新流程

这个 PR 的客户端侧**已经接好了**，但需要配套的后端路由才能真正取到歌。两边可以独立合入，顺序不限。

### 现在合并会发生什么

后端还没有 `/user/playlist-detail` 时，新路由请求会 404。客户端把 404 当成「这个后端没有声明这个能力」，**静默回落到原来的匿名路径**，行为与合并前完全一致，唯一区别是：

- 读不到的不公开歌单，界面从「暂无内容」变成「这个歌单不是公开歌单，当前音源接口读不到它的内容」。

也就是说合并本身零风险，不依赖后端进度。

### 后端需要实现什么

新增一条带凭据的歌单取歌路由，复用包里已有的 `music.srfDissInfo.DissInfo` / `CgiGetDiss` 调用（目前被写死成 `dirid: 201` 只服务「我喜欢」）。完整方案已单独提交给后端。

客户端按这个契约发请求，**与 `/user/liked-songs` 完全同形**：

```
GET /user/playlist-detail?tid=<tid>&dirid=<dirId>&offset=0&limit=100
     凭据：Cookie / ?cookie= / X-QQ-Session，与其余 /user/* 一致

200  { "code": 200, "songs": [...], "total": 8, "more": false }
401  { "code": 401, "message": "Login required" }
```

### 后端就绪后要做的

**只有一步：升级 `@yakult-green-tea/qq-music-api` 版本。** 这里不需要再改任何代码。

### 验收

1. 在 QQ 音乐 App 里确认某个自建歌单是**不公开**的（`dirShow: 2`）；
2. 在 Folia 里打开它 —— 升级前显示「不是公开歌单」，升级后正常出歌；
3. 顺带确认「我喜欢」没有回归（它走的是另一条路由，不受影响）。

开发环境下可以用 `npm run dev` 打开 `/qq-diag.html` 看原始字段和上游状态码。

### 后端就绪后可选的清理

确认生效后，以下两处过渡代码可以删掉：

- `normalizeQqCollection` 里的 `dirShow` 保留
- `loadRawPlaylistTracks` 里的 `unsupported` 分支

不删也不影响 —— 对收藏的公开歌单它们仍然是正确的兜底。

---

## 问题

用户反馈：QQ 音乐登录后「我喜欢」正常，**所有自建歌单点开都是空的，且没有任何报错**，但歌单卡片上的歌曲数量是对的。

## 根因

`/getSongListDetail` 的上游是匿名 CGI。歌单不公开时它**照样回 `code: 0`**，只是 `cdlist[0]` 退化成一个空壳 —— 没有 `disstid`、没有 `dissname`，`songlist` 是空数组。

用真实账号做的对照实验：同一个歌单，只把 `dirShow` 从 `1` 改成 `2`，tid 和请求都没变，结果从 2 首变成 0 首。可见性是唯一变量（`dir_show`：1 公开、2 不公开）。

「我喜欢」不受影响，是因为 `dirId === 201` 走的是带凭据的 `/user/liked-songs`，绕开了这条 CGI。这也解释了为什么「新建一个只有 1 首歌的歌单也是空的」—— 新建歌单默认不公开，和歌曲数量无关。

排除项：Koa 版与 serverless 版后端用同样的 tid 打同一条路由结果逐条一致，不是部署形态问题；上游成功时回声的 `disstid` 与列表里的 `tid` 相同，id 语义也没有错。

## 改了什么

### 1. 失败不再静默退化成空结果

链路上有三处把失败吞掉：

- `song_list_detail` 没登记进 `CATALOG_STATUS_NODES`，上游用 HTTP 200 加响应体状态码表达拒收，于是拒收一路变成空列表；
- `loadRawPlaylistTracks` 无法区分「没读到歌单」和「歌单是空的」。判据改用上游有没有回声 `disstid` —— 真的空歌单会带着完整的 `disstid` / `dissname` 回来，空壳不会。**按 `cdlist` 长度判断抓不到这种情况，因为 `cdlist[0]` 是在的**；
- `GridView` 的 catch 只 `console.error`，界面上没有任何失败态。

歌单已知不公开时报 `unsupported` 而非 `invalid-response`：协议没有坏，是这条匿名路由没资格读它。界面据此给一句用户能看懂的解释，而不是把协议细节甩到屏幕上。

### 2. 自建歌单改走带凭据的路由

| 集合 | 走哪条 | 理由 |
| --- | --- | --- |
| 我喜欢（`dirId === 201`） | `/user/liked-songs`（不变） | 本来就正常，没必要让它承担新后端的风险 |
| 其余自建歌单（有 `dirId`） | `/user/playlist-detail`（新） | 只有它读得到不公开歌单，且支持真正分页 |
| 收藏的、分享链接进来的 | `/getSongListDetail`（不变） | 没有 `dirId`，本来就只能走匿名路由 |

顺带解决：匿名路径每翻一页都要把整张歌单重新拉一遍，一个 958 首的歌单会被整体请求多次。新路由透传真实 `offset` / `limit`，这个问题一并消失。

### 3. 诊断探针（仅开发服务器）

定位这个 bug 时用的工具，留下来给下次排查。与 `dev-probe.html` 同规格 —— 不在 `vite.config.ts` 的 `build.rollupOptions.input` 里，**不会进生产产物**。需要在部署环境上排查时临时加进 build input 即可。

原始响应访问放在 `qqPlaylistDiagnostics.ts`，留在 adapter 层内，页面只消费稳定的探针类型。

## Review 要点

- **404 的语义变更**：transport 现在把 404 映射成 `unsupported` 而不是 `network`，这是全局行为。已确认仓库里没有任何代码依赖 404 → `network`（429 等其余状态码不受影响，有既有测试守着）。
- **只有 404 才算「后端不支持」**，其余失败照常抛出。否则一次网络抖动会被误判成后端不支持并在整个会话里粘住 —— 那比原 bug 更难查。有专门的测试守这条。
- **探测结果按会话缓存**：后端版本一个会话内不会变，探到一次 404 就不再为每一页重试；刷新页面自然重新探测。
- 一条旧 fixture 缺 `disstid` 一并补上 —— 真实上游的成功响应一定回声它，之前那个形状不成立。

## 验证

- `npx tsc --noEmit` 干净
- `npm run test:unit`：**3280 passed / 1 skipped**（新增 8 条，skip 是原有的）
- `npm run build` 成功，确认 `dist/` 里没有 `qq-diag.html`

新增测试覆盖：走新路由并透传分页窗口、404 回落且只回落一次、网络错误不被误判、旧后端 + 不公开歌单（反馈者升级前的处境）仍能正确报错、真的空歌单仍然是成功的空页。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PV9GFADPnuTV5uVBUCRfcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PV9GFADPnuTV5uVBUCRfcs)_