### PR TITLE
fix(ai): 改进自定义 OpenAI-compatible 接口兼容性

### DIFF
--- a/api-ts/generate-theme_openai.ts
+++ b/api-ts/generate-theme_openai.ts
@@ -10,6 +10,7 @@ const DEFAULT_OPENAI_MODEL = 'gpt-5.6-luna';
 const DEFAULT_OPENAI_TEMPERATURE = 0.7;
 const DEEPSEEK_DEFAULT_MODEL = 'deepseek-v4-flash';
 const THEME_JSON_SCHEMA_NAME = 'dual_theme';
+const THEME_MAX_OUTPUT_TOKENS = 4096;
 
 const THEME_JSON_SCHEMA = {
     type: 'object',
@@ -148,10 +149,6 @@ const detectOpenAICompatibleProvider = (apiUrl: string, model: string): OpenAICo
         // Fall through to generic provider handling.
     }
 
-    if (/^(gpt|o[1-9]|o[1-9]-|chatgpt-)/.test(normalizedModel)) {
-        return 'openai';
-    }
-
     return 'generic';
 };
 
@@ -276,6 +273,7 @@ const buildOpenAICompatibleRequestBody = (
             model,
             messages,
             temperature,
+            max_tokens: THEME_MAX_OUTPUT_TOKENS,
             response_format: {
                 type: 'json_schema',
                 json_schema: {
@@ -291,6 +289,7 @@ const buildOpenAICompatibleRequestBody = (
         model,
         messages,
         temperature,
+        max_tokens: THEME_MAX_OUTPUT_TOKENS,
         response_format: { type: 'json_object' }
     };
 };
@@ -318,6 +317,39 @@ const extractResponseContentText = (message: { content?: unknown; refusal?: unkn
     }
 
     return null;
+};
+
+const parseAiJsonObject = (input: string, requiredKeys: string[] = []): Record<string, unknown> => {
+    const text = input.trim();
+    for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+        let depth = 0;
+        let inString = false;
+        let escaped = false;
+        for (let index = start; index < text.length; index += 1) {
+            const char = text[index];
+            if (inString) {
+                if (escaped) escaped = false;
+                else if (char === '\\') escaped = true;
+                else if (char === '"') inString = false;
+                continue;
+            }
+            if (char === '"') inString = true;
+            else if (char === '{') depth += 1;
+            else if (char === '}' && --depth === 0) {
+                try {
+                    const parsed: unknown = JSON.parse(text.slice(start, index + 1));
+                    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                        && requiredKeys.every((key) => Object.hasOwn(parsed, key))) {
+                        return parsed as Record<string, unknown>;
+                    }
+                } catch {
+                    break;
+                }
+            }
+        }
+    }
+    const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+    throw new Error(`AI response did not contain a valid JSON object${requirement}`);
 };
 
 export default async function handler(req: Request) {
@@ -382,20 +414,11 @@ export default async function handler(req: Request) {
             throw new Error("Failed to generate theme JSON");
         }
 
-        // Attempt to parse JSON
         let dualTheme;
-        let jsonStr = content.trim();
-
-        // Remove markdown code blocks if present
-        if (jsonStr.startsWith('```')) {
-            jsonStr = jsonStr.replace(/^```(json)?\n/, '').replace(/\n```$/, '');
-        }
-
         try {
-            dualTheme = sanitizeDualTheme(JSON.parse(jsonStr));
+            dualTheme = sanitizeDualTheme(parseAiJsonObject(content, ['light', 'dark']));
         } catch (e) {
-            console.error("Failed to parse JSON from AI response:", jsonStr);
-            throw new Error("Invalid JSON response from AI");
+            throw new Error(`Invalid JSON response from AI: ${e instanceof Error ? e.message : String(e)}`);
         }
 
         // Force fixed properties for both themes

--- a/api-ts/generate-theme_openai.ts
+++ b/api-ts/generate-theme_openai.ts
@@ -1,3 +1,4 @@
+import { fetchOpenAICompatible } from '../shared/openAICompatibility.mjs';
 import { sanitizeDualTheme } from "../shared/themeSanitizer.mjs";
 
 // 当前文件：Vercel OpenAI 兼容主题生成函数的 TypeScript 源文件。
@@ -132,10 +133,6 @@ const resolveOpenAICompatibleModel = (apiUrl: string, configuredModel?: string) 
 };
 
 const detectOpenAICompatibleProvider = (apiUrl: string, model: string): OpenAICompatibleProvider => {
-    const normalizedModel = model.trim().toLowerCase();
-    if (normalizedModel.startsWith('deepseek-')) {
-        return 'deepseek';
-    }
 
     try {
         const hostname = new URL(apiUrl).hostname.toLowerCase();
@@ -273,7 +270,7 @@ const buildOpenAICompatibleRequestBody = (
             model,
             messages,
             temperature,
-            max_tokens: THEME_MAX_OUTPUT_TOKENS,
+            max_completion_tokens: THEME_MAX_OUTPUT_TOKENS,
             response_format: {
                 type: 'json_schema',
                 json_schema: {
@@ -289,7 +286,7 @@ const buildOpenAICompatibleRequestBody = (
         model,
         messages,
         temperature,
-        max_tokens: THEME_MAX_OUTPUT_TOKENS,
+        max_tokens: 8192,
         response_format: { type: 'json_object' }
     };
 };
@@ -321,11 +318,13 @@ const extractResponseContentText = (message: { content?: unknown; refusal?: unkn
 
 const parseAiJsonObject = (input: string, requiredKeys: string[] = []): Record<string, unknown> => {
     const text = input.trim();
-    for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+    // Bound malformed-input scanning; normal theme objects fit comfortably within this limit.
+    let candidates = 0;
+    for (let start = text.indexOf('{'); start !== -1 && candidates++ < 64; start = text.indexOf('{', start + 1)) {
         let depth = 0;
         let inString = false;
         let escaped = false;
-        for (let index = start; index < text.length; index += 1) {
+        for (let index = start; index < Math.min(text.length, start + 131072); index += 1) {
             const char = text[index];
             if (inString) {
                 if (escaped) escaped = false;
@@ -349,6 +348,7 @@ const parseAiJsonObject = (input: string, requiredKeys: string[] = []): Record<s
         }
     }
     const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+    console.error('[ai] invalid JSON response:', JSON.stringify({ length: text.length, preview: text.slice(0, 512).replace(/sk-[a-zA-Z0-9_-]+|Bearer\s+[^\s"']+/g, '[redacted]') }));
     throw new Error(`AI response did not contain a valid JSON object${requirement}`);
 };
 
@@ -392,14 +392,15 @@ export default async function handler(req: Request) {
         const systemPrompt = buildThemeSystemPrompt(true);
         const sourcePrompt = buildThemeSourcePrompt(snippet, isPureMusic, songTitle);
 
-        const response = await fetch(apiUrl, {
+        const response = await fetchOpenAICompatible(apiUrl, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 "Authorization": `Bearer ${apiKey}`,
             },
             body: JSON.stringify(buildOpenAICompatibleRequestBody(model, provider, systemPrompt, sourcePrompt, temperature)),
-        });
+            signal: AbortSignal.timeout(120_000),
+        }, provider);
 
         if (!response.ok) {
             const errorMessage = await formatOpenAICompatibleError(response);

--- a/api/generate-theme_openai.js
+++ b/api/generate-theme_openai.js
@@ -1,3 +1,4 @@
+import { fetchOpenAICompatible } from '../shared/openAICompatibility.mjs';
 import { sanitizeDualTheme } from "../shared/themeSanitizer.mjs";
 // 当前文件：Vercel OpenAI 兼容主题生成函数的 TypeScript 源文件。
 export const config = {
@@ -120,10 +121,6 @@ const resolveOpenAICompatibleModel = (apiUrl, configuredModel) => {
     return DEFAULT_OPENAI_MODEL;
 };
 const detectOpenAICompatibleProvider = (apiUrl, model) => {
-    const normalizedModel = model.trim().toLowerCase();
-    if (normalizedModel.startsWith('deepseek-')) {
-        return 'deepseek';
-    }
     try {
         const hostname = new URL(apiUrl).hostname.toLowerCase();
         if (hostname === 'api.deepseek.com' || hostname.endsWith('.deepseek.com')) {
@@ -241,7 +238,7 @@ const buildOpenAICompatibleRequestBody = (model, provider, systemPrompt, sourceP
             model,
             messages,
             temperature,
-            max_tokens: THEME_MAX_OUTPUT_TOKENS,
+            max_completion_tokens: THEME_MAX_OUTPUT_TOKENS,
             response_format: {
                 type: 'json_schema',
                 json_schema: {
@@ -256,7 +253,7 @@ const buildOpenAICompatibleRequestBody = (model, provider, systemPrompt, sourceP
         model,
         messages,
         temperature,
-        max_tokens: THEME_MAX_OUTPUT_TOKENS,
+        max_tokens: 8192,
         response_format: { type: 'json_object' }
     };
 };
@@ -282,11 +279,13 @@ const extractResponseContentText = (message) => {
 };
 const parseAiJsonObject = (input, requiredKeys = []) => {
     const text = input.trim();
-    for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+    // Bound malformed-input scanning; normal theme objects fit comfortably within this limit.
+    let candidates = 0;
+    for (let start = text.indexOf('{'); start !== -1 && candidates++ < 64; start = text.indexOf('{', start + 1)) {
         let depth = 0;
         let inString = false;
         let escaped = false;
-        for (let index = start; index < text.length; index += 1) {
+        for (let index = start; index < Math.min(text.length, start + 131072); index += 1) {
             const char = text[index];
             if (inString) {
                 if (escaped)
@@ -316,6 +315,7 @@ const parseAiJsonObject = (input, requiredKeys = []) => {
         }
     }
     const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+    console.error('[ai] invalid JSON response:', JSON.stringify({ length: text.length, preview: text.slice(0, 512).replace(/sk-[a-zA-Z0-9_-]+|Bearer\s+[^\s"']+/g, '[redacted]') }));
     throw new Error(`AI response did not contain a valid JSON object${requirement}`);
 };
 export default async function handler(req) {
@@ -352,14 +352,15 @@ export default async function handler(req) {
         const snippet = lyricsText.slice(0, 2000);
         const systemPrompt = buildThemeSystemPrompt(true);
         const sourcePrompt = buildThemeSourcePrompt(snippet, isPureMusic, songTitle);
-        const response = await fetch(apiUrl, {
+        const response = await fetchOpenAICompatible(apiUrl, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 "Authorization": `Bearer ${apiKey}`,
             },
             body: JSON.stringify(buildOpenAICompatibleRequestBody(model, provider, systemPrompt, sourcePrompt, temperature)),
-        });
+            signal: AbortSignal.timeout(120_000),
+        }, provider);
         if (!response.ok) {
             const errorMessage = await formatOpenAICompatibleError(response);
             console.error("OpenAI API Error:", errorMessage);

--- a/api/generate-theme_openai.js
+++ b/api/generate-theme_openai.js
@@ -8,6 +8,7 @@ const DEFAULT_OPENAI_MODEL = 'gpt-5.6-luna';
 const DEFAULT_OPENAI_TEMPERATURE = 0.7;
 const DEEPSEEK_DEFAULT_MODEL = 'deepseek-v4-flash';
 const THEME_JSON_SCHEMA_NAME = 'dual_theme';
+const THEME_MAX_OUTPUT_TOKENS = 4096;
 const THEME_JSON_SCHEMA = {
     type: 'object',
     additionalProperties: false,
@@ -135,9 +136,6 @@ const detectOpenAICompatibleProvider = (apiUrl, model) => {
     catch {
         // Fall through to generic provider handling.
     }
-    if (/^(gpt|o[1-9]|o[1-9]-|chatgpt-)/.test(normalizedModel)) {
-        return 'openai';
-    }
     return 'generic';
 };
 const providerSupportsStructuredOutputs = (provider) => provider === 'openai';
@@ -243,6 +241,7 @@ const buildOpenAICompatibleRequestBody = (model, provider, systemPrompt, sourceP
             model,
             messages,
             temperature,
+            max_tokens: THEME_MAX_OUTPUT_TOKENS,
             response_format: {
                 type: 'json_schema',
                 json_schema: {
@@ -257,6 +256,7 @@ const buildOpenAICompatibleRequestBody = (model, provider, systemPrompt, sourceP
         model,
         messages,
         temperature,
+        max_tokens: THEME_MAX_OUTPUT_TOKENS,
         response_format: { type: 'json_object' }
     };
 };
@@ -279,6 +279,44 @@ const extractResponseContentText = (message) => {
         return text || null;
     }
     return null;
+};
+const parseAiJsonObject = (input, requiredKeys = []) => {
+    const text = input.trim();
+    for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+        let depth = 0;
+        let inString = false;
+        let escaped = false;
+        for (let index = start; index < text.length; index += 1) {
+            const char = text[index];
+            if (inString) {
+                if (escaped)
+                    escaped = false;
+                else if (char === '\\')
+                    escaped = true;
+                else if (char === '"')
+                    inString = false;
+                continue;
+            }
+            if (char === '"')
+                inString = true;
+            else if (char === '{')
+                depth += 1;
+            else if (char === '}' && --depth === 0) {
+                try {
+                    const parsed = JSON.parse(text.slice(start, index + 1));
+                    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                        && requiredKeys.every((key) => Object.hasOwn(parsed, key))) {
+                        return parsed;
+                    }
+                }
+                catch {
+                    break;
+                }
+            }
+        }
+    }
+    const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+    throw new Error(`AI response did not contain a valid JSON object${requirement}`);
 };
 export default async function handler(req) {
     if (req.method !== 'POST') {
@@ -332,19 +370,12 @@ export default async function handler(req) {
         if (!content) {
             throw new Error("Failed to generate theme JSON");
         }
-        // Attempt to parse JSON
         let dualTheme;
-        let jsonStr = content.trim();
-        // Remove markdown code blocks if present
-        if (jsonStr.startsWith('```')) {
-            jsonStr = jsonStr.replace(/^```(json)?\n/, '').replace(/\n```$/, '');
-        }
         try {
-            dualTheme = sanitizeDualTheme(JSON.parse(jsonStr));
+            dualTheme = sanitizeDualTheme(parseAiJsonObject(content, ['light', 'dark']));
         }
         catch (e) {
-            console.error("Failed to parse JSON from AI response:", jsonStr);
-            throw new Error("Invalid JSON response from AI");
+            throw new Error(`Invalid JSON response from AI: ${e instanceof Error ? e.message : String(e)}`);
         }
         // Force fixed properties for both themes
         dualTheme.light.fontStyle = 'sans';

--- a/electron/aiTextClient.cjs
+++ b/electron/aiTextClient.cjs
@@ -108,10 +108,6 @@ function detectOpenAICompatibleProvider(apiUrl, model) {
     // Fall through to generic provider handling.
   }
 
-  if (/^(gpt|o[1-9]|o[1-9]-|chatgpt-)/.test(normalizedModel)) {
-    return 'openai';
-  }
-
   return 'generic';
 }
 
@@ -241,6 +237,41 @@ function extractResponseContentText(message) {
   return null;
 }
 
+/** Parses a JSON object even when an OpenAI-compatible endpoint wraps it in a fence or prose. */
+function parseAiJsonObject(input, requiredKeys = []) {
+  const text = typeof input === 'string' ? input.trim() : '';
+
+  for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = start; index < text.length; index += 1) {
+      const char = text[index];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (char === '\\') escaped = true;
+        else if (char === '"') inString = false;
+        continue;
+      }
+      if (char === '"') inString = true;
+      else if (char === '{') depth += 1;
+      else if (char === '}' && --depth === 0) {
+        try {
+          const parsed = JSON.parse(text.slice(start, index + 1));
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+            && requiredKeys.every((key) => Object.hasOwn(parsed, key))) return parsed;
+        } catch {
+          break;
+        }
+      }
+    }
+  }
+
+  const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+  throw new Error(`AI response did not contain a valid JSON object${requirement}`);
+}
+
 /**
  * Chat-completions body for any OpenAI-compatible endpoint. `schema` and `schemaName` are only
  * used on providers that support structured outputs; everywhere else they are ignored and the
@@ -355,7 +386,17 @@ async function runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt
     const described = Object.keys(params).length ? Object.keys(params).join('+') : 'plain';
     console.log(`[ai] POST ${apiUrl} model=${model} provider=${provider} reasoning=${described}`);
     const startedAt = Date.now();
-    const result = await sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeoutMs });
+    let result = await sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeoutMs });
+
+    const shouldRetryWithoutJsonMode = provider === 'generic' && body.response_format
+      && ((result.ok && !result.content && !exhaustedByReasoning(result.choice, result.usage))
+        || (!result.ok && result.status === 429 && /concurrency limit exceeded/i.test(result.errorText)));
+    if (shouldRetryWithoutJsonMode) {
+      console.log('[ai] generic JSON mode failed, retrying once without response_format');
+      const fallbackBody = { ...body };
+      delete fallbackBody.response_format;
+      result = await sendOpenAICompatible({ apiUrl, apiKey, body: fallbackBody, customFetch, timeoutMs });
+    }
 
     if (!result.ok) {
       // A rejected parameter is information, not a failure: this endpoint does not speak that
@@ -478,6 +519,7 @@ module.exports = {
   extractResponseContentText,
   formatOpenAICompatibleError,
   normalizeOpenAIChatCompletionsUrl,
+  parseAiJsonObject,
   providerSupportsStructuredOutputs,
   resolveOpenAICompatibleModel,
   resolveOpenAICompatibleTemperature,

--- a/electron/aiTextClient.cjs
+++ b/electron/aiTextClient.cjs
@@ -1,7 +1,5 @@
 "use strict";
 
-const { REASONING_SUPPRESSION_ATTEMPTS } = require('../shared/lyricSegmentationPrompt.cjs');
-
 // electron/aiTextClient.cjs
 // Provider-agnostic "send a system + user prompt, get JSON back" client for the main process.
 //
@@ -91,10 +89,6 @@ function resolveOpenAICompatibleModel(apiUrl, configuredModel) {
 }
 
 function detectOpenAICompatibleProvider(apiUrl, model) {
-  const normalizedModel = model.trim().toLowerCase();
-  if (normalizedModel.startsWith('deepseek-')) {
-    return 'deepseek';
-  }
 
   try {
     const hostname = new URL(apiUrl).hostname.toLowerCase();
@@ -114,34 +108,6 @@ function detectOpenAICompatibleProvider(apiUrl, model) {
 function providerSupportsStructuredOutputs(provider) {
   return provider === 'openai';
 }
-
-/**
- * Remembers which rung of REASONING_SUPPRESSION_ATTEMPTS worked for an endpoint+model, so the
- * probing is paid once per process rather than on every batch. Keyed by both because one base URL
- * can serve models with completely different capabilities.
- */
-const reasoningAttemptCache = new Map();
-
-/** True when a 400 is the server rejecting the parameter we just added, not a real failure. */
-const rejectsParameters = (errorText, params) => {
-  const message = String(errorText).toLowerCase();
-  return Object.keys(params).some(key => message.includes(key.toLowerCase()));
-};
-
-/**
- * True when the model answered nothing because reasoning consumed the whole budget. This is the
- * failure that looks like success: HTTP 200, tokens billed, `content` empty.
- */
-const exhaustedByReasoning = (choice, usage) => {
-  const reasoningTokens = usage
-    && usage.completion_tokens_details
-    && usage.completion_tokens_details.reasoning_tokens;
-  const hasReasoning = Boolean(
-    reasoningTokens || (choice && choice.message && choice.message.reasoning_content),
-  );
-  return hasReasoning && choice && choice.finish_reason === 'length';
-};
-
 
 function resolveOpenAICompatibleTemperature(value) {
   const temperature = typeof value === 'number' ? value : Number.parseFloat(String(value ?? '').trim());
@@ -203,7 +169,7 @@ function describeEmptyCompletion(choice, usage, model) {
     return `Model "${model}" used its entire output budget on reasoning`
       + `${reasoningTokens ? ` (${reasoningTokens} reasoning tokens)` : ''} and returned no answer.`
       + ' This is a reasoning model doing a mechanical task. Point the app at a non-reasoning model,'
-      + ' or raise the token limit if the provider ignores reasoning_effort.';
+      + ' or configure a compatible bounded output budget.';
   }
   if (finishReason === 'length') {
     return `Model "${model}" hit the output token limit before finishing its answer.`;
@@ -240,13 +206,16 @@ function extractResponseContentText(message) {
 /** Parses a JSON object even when an OpenAI-compatible endpoint wraps it in a fence or prose. */
 function parseAiJsonObject(input, requiredKeys = []) {
   const text = typeof input === 'string' ? input.trim() : '';
+  // ponytail: bounded candidate scan; use a streaming parser if larger responses are needed.
+  // Bound malformed-input scanning; normal theme objects fit comfortably within this limit.
+  let candidates = 0;
 
-  for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+  for (let start = text.indexOf('{'); start !== -1 && candidates++ < 64; start = text.indexOf('{', start + 1)) {
     let depth = 0;
     let inString = false;
     let escaped = false;
 
-    for (let index = start; index < text.length; index += 1) {
+    for (let index = start; index < Math.min(text.length, start + 131072); index += 1) {
       const char = text[index];
       if (inString) {
         if (escaped) escaped = false;
@@ -269,6 +238,7 @@ function parseAiJsonObject(input, requiredKeys = []) {
   }
 
   const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+  console.error('[ai] invalid JSON response:', JSON.stringify({ length: text.length, preview: text.slice(0, 512).replace(/sk-[a-zA-Z0-9_-]+|Bearer\s+[^\s"']+/g, '[redacted]') }));
   throw new Error(`AI response did not contain a valid JSON object${requirement}`);
 }
 
@@ -288,7 +258,7 @@ function buildOpenAICompatibleRequestBody(model, provider, systemPrompt, sourceP
   // unbounded body read, which presents as a request that never finishes. A caller that knows how
   // big its answer should be passes a ceiling; truncation then fails as a JSON parse error with
   // the raw response logged, which is diagnosable, unlike a hang.
-  const limit = maxTokens ? { max_tokens: maxTokens } : {};
+  const limit = maxTokens ? { [provider === 'openai' ? 'max_completion_tokens' : 'max_tokens']: maxTokens } : {};
   const reasoning = extraParams || {};
 
   if (schema && schemaName && providerSupportsStructuredOutputs(provider)) {
@@ -315,11 +285,12 @@ function buildOpenAICompatibleRequestBody(model, provider, systemPrompt, sourceP
   };
 }
 
-/** One request. Returns the outcome instead of throwing, so the ladder above can decide. */
+/** One request. Returns the outcome instead of throwing, with the shared capability policy. */
 async function sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeoutMs }) {
   let response;
   try {
-    response = await customFetch(apiUrl, {
+    const { fetchOpenAICompatible } = await import('../shared/openAICompatibility.mjs');
+    response = await fetchOpenAICompatible(apiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -327,7 +298,7 @@ async function sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeout
       },
       body: JSON.stringify(body),
       signal: timeoutSignal(timeoutMs),
-    });
+    }, detectOpenAICompatibleProvider(apiUrl, body.model), customFetch);
   } catch (error) {
     throw describeFetchFailure(error, timeoutMs, `Request to ${apiUrl}`);
   }
@@ -347,16 +318,8 @@ async function sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeout
   return { ok: true, choice, usage: data.usage, content: extractResponseContentText(choice && choice.message) };
 }
 
-/**
- * Raw JSON text from an OpenAI-compatible endpoint, using the user's configured connection.
- *
- * When `disableReasoning` is set this walks REASONING_SUPPRESSION_ATTEMPTS rather than assuming
- * anything about the provider, advancing on the two failures that mean "that rung does not apply
- * here": the server rejecting the parameter, and the model answering nothing because reasoning ate
- * the budget. Any other error is real and is reported immediately, so a bad key or a wrong model
- * name still fails on the first request instead of being retried three times.
- */
-async function runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs = DEFAULT_AI_TIMEOUT_MS, maxTokens, disableReasoning }) {
+/** One bounded completion, with only explicit HTTP capability fallbacks. */
+async function runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs = DEFAULT_AI_TIMEOUT_MS, maxTokens }) {
   const apiKey = store.get('OPENAI_API_KEY');
   if (!apiKey) {
     throw new Error('OPENAI_API_KEY is not configured in settings');
@@ -367,67 +330,15 @@ async function runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt
   const temperature = resolveOpenAICompatibleTemperature(store.get('OPENAI_API_TEMPERATURE'));
   const provider = detectOpenAICompatibleProvider(apiUrl, model);
 
-  const attempts = disableReasoning ? REASONING_SUPPRESSION_ATTEMPTS : [{ params: {} }];
-  const cacheKey = `${apiUrl}|${model}`;
-  const learned = disableReasoning ? reasoningAttemptCache.get(cacheKey) : 0;
-  const firstIndex = typeof learned === 'number' ? learned : 0;
-
-  let lastEmpty = null;
-  for (let index = firstIndex; index < attempts.length; index += 1) {
-    const { params } = attempts[index];
-    const isLastAttempt = index === attempts.length - 1;
-    // The final rung is for models whose reasoning cannot be turned off, so it needs room for the
-    // reasoning AND the answer; the earlier rungs expect no reasoning at all.
-    const budget = isLastAttempt && disableReasoning && maxTokens ? maxTokens * 4 : maxTokens;
-    const body = buildOpenAICompatibleRequestBody(
-      model, provider, systemPrompt, sourcePrompt, temperature, schema, schemaName, budget, params,
-    );
-
-    const described = Object.keys(params).length ? Object.keys(params).join('+') : 'plain';
-    console.log(`[ai] POST ${apiUrl} model=${model} provider=${provider} reasoning=${described}`);
-    const startedAt = Date.now();
-    let result = await sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeoutMs });
-
-    const shouldRetryWithoutJsonMode = provider === 'generic' && body.response_format
-      && ((result.ok && !result.content && !exhaustedByReasoning(result.choice, result.usage))
-        || (!result.ok && result.status === 429 && /concurrency limit exceeded/i.test(result.errorText)));
-    if (shouldRetryWithoutJsonMode) {
-      console.log('[ai] generic JSON mode failed, retrying once without response_format');
-      const fallbackBody = { ...body };
-      delete fallbackBody.response_format;
-      result = await sendOpenAICompatible({ apiUrl, apiKey, body: fallbackBody, customFetch, timeoutMs });
-    }
-
-    if (!result.ok) {
-      // A rejected parameter is information, not a failure: this endpoint does not speak that
-      // dialect, so move down the ladder. Everything else is the user's problem to see.
-      if (!isLastAttempt && (result.status === 400 || result.status === 422) && rejectsParameters(result.errorText, params)) {
-        console.log(`[ai] ${described} rejected by the endpoint, trying the next option`);
-        continue;
-      }
-      throw new Error(result.errorText);
-    }
-
-    console.log(`[ai] ${apiUrl} answered in ${Date.now() - startedAt}ms`);
-
-    if (result.content) {
-      reasoningAttemptCache.set(cacheKey, index);
-      return result.content;
-    }
-
-    lastEmpty = result;
-    if (!isLastAttempt && exhaustedByReasoning(result.choice, result.usage)) {
-      console.log(`[ai] ${described} did not stop the model reasoning, trying the next option`);
-      continue;
-    }
-    break;
-  }
-
-  throw new Error(describeEmptyCompletion(
-    lastEmpty && lastEmpty.choice,
-    lastEmpty && lastEmpty.usage,
-    model,
-  ));
+  const body = buildOpenAICompatibleRequestBody(
+    model, provider, systemPrompt, sourcePrompt, temperature, schema, schemaName, maxTokens,
+  );
+  const startedAt = Date.now();
+  const result = await sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeoutMs });
+  console.info(`[ai] ${provider} completion in ${Date.now() - startedAt}ms (ok=${result.ok})`);
+  if (!result.ok) throw new Error(result.errorText);
+  if (result.content) return result.content;
+  throw new Error(describeEmptyCompletion(result.choice, result.usage, model));
 }
 
 /**
@@ -499,11 +410,11 @@ async function runGeminiCompletion({ store, systemPrompt, sourcePrompt, response
  * Runs one prompt through whichever provider the user configured and returns the raw JSON text.
  * Parsing is left to the caller so each feature can validate against its own contract.
  */
-async function runAiJsonCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, geminiResponseSchema, geminiGenerationConfig, customFetch, timeoutMs, maxTokens, disableReasoning }) {
+async function runAiJsonCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, geminiResponseSchema, geminiGenerationConfig, customFetch, timeoutMs, maxTokens }) {
   const provider = store.get('AI_PROVIDER') || 'gemini';
 
   return provider === 'openai'
-    ? runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs, maxTokens, disableReasoning })
+    ? runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs, maxTokens })
     : runGeminiCompletion({ store, systemPrompt, sourcePrompt, responseSchema: geminiResponseSchema, generationConfig: geminiGenerationConfig, customFetch, timeoutMs, maxTokens });
 }
 

--- a/electron/aiTextClient.cjs
+++ b/electron/aiTextClient.cjs
@@ -1,5 +1,7 @@
 "use strict";
 
+const { REASONING_SUPPRESSION_ATTEMPTS } = require('../shared/lyricSegmentationPrompt.cjs');
+
 // electron/aiTextClient.cjs
 // Provider-agnostic "send a system + user prompt, get JSON back" client for the main process.
 //
@@ -109,6 +111,28 @@ function providerSupportsStructuredOutputs(provider) {
   return provider === 'openai';
 }
 
+/**
+ * Remembers which rung of REASONING_SUPPRESSION_ATTEMPTS worked for an endpoint+model, so the
+ * probing is paid once per process rather than on every batch. Keyed by both because one base URL
+ * can serve models with completely different capabilities.
+ */
+const reasoningAttemptCache = new Map();
+
+/**
+ * True when the model answered nothing because reasoning consumed the whole budget. This is the
+ * failure that looks like success: HTTP 200, tokens billed, `content` empty.
+ */
+const exhaustedByReasoning = (choice, usage) => {
+  const reasoningTokens = usage
+    && usage.completion_tokens_details
+    && usage.completion_tokens_details.reasoning_tokens;
+  const hasReasoning = Boolean(
+    reasoningTokens || (choice && choice.message && choice.message.reasoning_content),
+  );
+  return hasReasoning && choice && choice.finish_reason === 'length';
+};
+
+
 function resolveOpenAICompatibleTemperature(value) {
   const temperature = typeof value === 'number' ? value : Number.parseFloat(String(value ?? '').trim());
   return Number.isFinite(temperature) && temperature >= 0 && temperature <= 2
@@ -206,7 +230,6 @@ function extractResponseContentText(message) {
 /** Parses a JSON object even when an OpenAI-compatible endpoint wraps it in a fence or prose. */
 function parseAiJsonObject(input, requiredKeys = []) {
   const text = typeof input === 'string' ? input.trim() : '';
-  // ponytail: bounded candidate scan; use a streaming parser if larger responses are needed.
   // Bound malformed-input scanning; normal theme objects fit comfortably within this limit.
   let candidates = 0;
 
@@ -318,8 +341,8 @@ async function sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeout
   return { ok: true, choice, usage: data.usage, content: extractResponseContentText(choice && choice.message) };
 }
 
-/** One bounded completion, with only explicit HTTP capability fallbacks. */
-async function runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs = DEFAULT_AI_TIMEOUT_MS, maxTokens }) {
+/** Retains the segmentation suppression ladder; each rung uses the HTTP capability policy. */
+async function runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs = DEFAULT_AI_TIMEOUT_MS, maxTokens, disableReasoning }) {
   const apiKey = store.get('OPENAI_API_KEY');
   if (!apiKey) {
     throw new Error('OPENAI_API_KEY is not configured in settings');
@@ -330,15 +353,59 @@ async function runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt
   const temperature = resolveOpenAICompatibleTemperature(store.get('OPENAI_API_TEMPERATURE'));
   const provider = detectOpenAICompatibleProvider(apiUrl, model);
 
-  const body = buildOpenAICompatibleRequestBody(
-    model, provider, systemPrompt, sourcePrompt, temperature, schema, schemaName, maxTokens,
-  );
-  const startedAt = Date.now();
-  const result = await sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeoutMs });
-  console.info(`[ai] ${provider} completion in ${Date.now() - startedAt}ms (ok=${result.ok})`);
-  if (!result.ok) throw new Error(result.errorText);
-  if (result.content) return result.content;
-  throw new Error(describeEmptyCompletion(result.choice, result.usage, model));
+  const attempts = disableReasoning ? REASONING_SUPPRESSION_ATTEMPTS : [{ params: {} }];
+  const cacheKey = `${apiUrl}|${model}`;
+  const learned = disableReasoning ? reasoningAttemptCache.get(cacheKey) : 0;
+  const firstIndex = typeof learned === 'number' ? learned : 0;
+
+  const { rejectsParameter } = await import('../shared/openAICompatibility.mjs');
+
+  let lastEmpty = null;
+  for (let index = firstIndex; index < attempts.length; index += 1) {
+    const { params } = attempts[index];
+    const isLastAttempt = index === attempts.length - 1;
+    // The final rung is for models whose reasoning cannot be turned off, so it needs room for the
+    // reasoning AND the answer; the earlier rungs expect no reasoning at all.
+    const budget = isLastAttempt && disableReasoning && maxTokens ? maxTokens * 4 : maxTokens;
+    const body = buildOpenAICompatibleRequestBody(
+      model, provider, systemPrompt, sourcePrompt, temperature, schema, schemaName, budget, params,
+    );
+
+    const described = Object.keys(params).length ? Object.keys(params).join('+') : 'plain';
+    console.log(`[ai] provider=${provider} reasoning=${described}`);
+    const startedAt = Date.now();
+    const result = await sendOpenAICompatible({ apiUrl, apiKey, body, customFetch, timeoutMs });
+
+    if (!result.ok) {
+      // A rejected parameter is information, not a failure: this endpoint does not speak that
+      // dialect, so move down the ladder. Everything else is the user's problem to see.
+      if (!isLastAttempt && Object.keys(params).some(key => rejectsParameter(result.status, result.errorText, key))) {
+        console.log(`[ai] ${described} rejected by the endpoint, trying the next option`);
+        continue;
+      }
+      throw new Error(result.errorText);
+    }
+
+    console.log(`[ai] ${provider} answered in ${Date.now() - startedAt}ms`);
+
+    if (result.content) {
+      if (disableReasoning) reasoningAttemptCache.set(cacheKey, index);
+      return result.content;
+    }
+
+    lastEmpty = result;
+    if (!isLastAttempt && exhaustedByReasoning(result.choice, result.usage)) {
+      console.log(`[ai] ${described} did not stop the model reasoning, trying the next option`);
+      continue;
+    }
+    break;
+  }
+
+  throw new Error(describeEmptyCompletion(
+    lastEmpty && lastEmpty.choice,
+    lastEmpty && lastEmpty.usage,
+    model,
+  ));
 }
 
 /**
@@ -410,11 +477,11 @@ async function runGeminiCompletion({ store, systemPrompt, sourcePrompt, response
  * Runs one prompt through whichever provider the user configured and returns the raw JSON text.
  * Parsing is left to the caller so each feature can validate against its own contract.
  */
-async function runAiJsonCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, geminiResponseSchema, geminiGenerationConfig, customFetch, timeoutMs, maxTokens }) {
+async function runAiJsonCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, geminiResponseSchema, geminiGenerationConfig, customFetch, timeoutMs, maxTokens, disableReasoning }) {
   const provider = store.get('AI_PROVIDER') || 'gemini';
 
   return provider === 'openai'
-    ? runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs, maxTokens })
+    ? runOpenAICompatibleCompletion({ store, systemPrompt, sourcePrompt, schema, schemaName, customFetch, timeoutMs, maxTokens, disableReasoning })
     : runGeminiCompletion({ store, systemPrompt, sourcePrompt, responseSchema: geminiResponseSchema, generationConfig: geminiGenerationConfig, customFetch, timeoutMs, maxTokens });
 }
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -37,13 +37,7 @@ const { createTranscodeService } = require('./transcode/service.cjs');
 const { TRANSCODE_PROTOCOL_SCHEME } = require('./transcode/protocol.cjs');
 const { sanitizeDualTheme: sanitizeGeneratedDualTheme } = require('../shared/themeSanitizer.cjs');
 const {
-  buildOpenAICompatibleRequestBody,
-  detectOpenAICompatibleProvider,
-  extractResponseContentText,
-  formatOpenAICompatibleError,
-  normalizeOpenAIChatCompletionsUrl,
-  resolveOpenAICompatibleModel,
-  resolveOpenAICompatibleTemperature,
+  parseAiJsonObject,
   runAiJsonCompletion,
 } = require('./aiTextClient.cjs');
 const {
@@ -3601,6 +3595,7 @@ async function generateGeminiTheme({ apiKey, systemPrompt, sourcePrompt, customF
 }
 
 const THEME_JSON_SCHEMA_NAME = 'dual_theme';
+const THEME_MAX_OUTPUT_TOKENS = 4096;
 const THEME_JSON_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -6600,40 +6595,19 @@ ipcMain.handle('generate-theme', async (event, lyricsText, options = {}) => {
     let dualTheme = null;
 
     if (provider === 'openai') {
-      const apiKey = store.get('OPENAI_API_KEY');
-      const apiUrl = normalizeOpenAIChatCompletionsUrl(store.get('OPENAI_API_URL'));
-      const model = resolveOpenAICompatibleModel(apiUrl, store.get('OPENAI_API_MODEL'));
-      const temperature = resolveOpenAICompatibleTemperature(store.get('OPENAI_API_TEMPERATURE'));
-      const openAICompatibleProvider = detectOpenAICompatibleProvider(apiUrl, model);
       const systemPrompt = buildThemeSystemPrompt(true);
       const sourcePrompt = buildThemeSourcePrompt(snippet, isPureMusic, songTitle);
-
-      if (!apiKey) {
-        throw new Error("OPENAI_API_KEY is not configured in settings");
-      }
-
-      const response = await customFetch(apiUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify(buildOpenAICompatibleRequestBody(model, openAICompatibleProvider, systemPrompt, sourcePrompt, temperature, THEME_JSON_SCHEMA, THEME_JSON_SCHEMA_NAME)),
+      const content = await runAiJsonCompletion({
+        store,
+        systemPrompt,
+        sourcePrompt,
+        schema: THEME_JSON_SCHEMA,
+        schemaName: THEME_JSON_SCHEMA_NAME,
+        customFetch,
+        maxTokens: THEME_MAX_OUTPUT_TOKENS,
+        disableReasoning: true,
       });
-
-      if (!response.ok) {
-        throw new Error(await formatOpenAICompatibleError(response));
-      }
-
-      const data = await response.json();
-      const content = extractResponseContentText(data.choices[0]?.message);
-      if (!content) throw new Error("Failed to generate theme JSON");
-
-      let jsonStr = content.trim();
-      if (jsonStr.startsWith('```')) {
-        jsonStr = jsonStr.replace(/^```(json)?\n/, '').replace(/\n```$/, '');
-      }
-      dualTheme = sanitizeGeneratedDualTheme(JSON.parse(jsonStr));
+      dualTheme = sanitizeGeneratedDualTheme(parseAiJsonObject(content, ['light', 'dark']));
 
       dualTheme.light.provider = 'OpenAI Compatible (Local)';
       dualTheme.dark.provider = 'OpenAI Compatible (Local)';

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -37,6 +37,8 @@ const { createTranscodeService } = require('./transcode/service.cjs');
 const { TRANSCODE_PROTOCOL_SCHEME } = require('./transcode/protocol.cjs');
 const { sanitizeDualTheme: sanitizeGeneratedDualTheme } = require('../shared/themeSanitizer.cjs');
 const {
+  detectOpenAICompatibleProvider,
+  normalizeOpenAIChatCompletionsUrl,
   parseAiJsonObject,
   runAiJsonCompletion,
 } = require('./aiTextClient.cjs');
@@ -6604,8 +6606,7 @@ ipcMain.handle('generate-theme', async (event, lyricsText, options = {}) => {
         schema: THEME_JSON_SCHEMA,
         schemaName: THEME_JSON_SCHEMA_NAME,
         customFetch,
-        maxTokens: THEME_MAX_OUTPUT_TOKENS,
-        disableReasoning: true,
+        maxTokens: detectOpenAICompatibleProvider(normalizeOpenAIChatCompletionsUrl(store.get('OPENAI_API_URL')), '') === 'openai' ? THEME_MAX_OUTPUT_TOKENS : 8192,
       });
       dualTheme = sanitizeGeneratedDualTheme(parseAiJsonObject(content, ['light', 'dark']));
 
@@ -6670,10 +6671,6 @@ ipcMain.handle('segment-lyrics', async (event, lines) => {
       geminiGenerationConfig: SEGMENTATION_GEMINI_GENERATION_CONFIG,
       customFetch,
       maxTokens: SEGMENTATION_MAX_OUTPUT_TOKENS,
-      // Splitting text at word boundaries has nothing to reason about, and a reasoning model left
-      // to its own devices spends the whole budget thinking and returns nothing. Same reason the
-      // Gemini config sets thinkingBudget to 0.
-      disableReasoning: true,
     });
 
     const { boundaries, rejections } = parseSegmentationResponse(rawResponse, sourceLines);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -6671,6 +6671,8 @@ ipcMain.handle('segment-lyrics', async (event, lines) => {
       geminiGenerationConfig: SEGMENTATION_GEMINI_GENERATION_CONFIG,
       customFetch,
       maxTokens: SEGMENTATION_MAX_OUTPUT_TOKENS,
+      // Preserve the existing segmentation-only suppression ladder and final 4x budget.
+      disableReasoning: true,
     });
 
     const { boundaries, rejections } = parseSegmentationResponse(rawResponse, sourceLines);

--- a/shared/lyricSegmentationService.mjs
+++ b/shared/lyricSegmentationService.mjs
@@ -1,4 +1,4 @@
-import { fetchOpenAICompatible } from './openAICompatibility.mjs';
+import { fetchOpenAICompatible, rejectsParameter } from './openAICompatibility.mjs';
 // shared/lyricSegmentationService.mjs
 // Server-side lyric word segmentation, shared by the Vercel edge handler and the Cloudflare
 // Worker. Those two runtimes differ only in where the environment comes from, so they are thin
@@ -9,6 +9,7 @@ import { fetchOpenAICompatible } from './openAICompatibility.mjs';
 // build there is no user-facing setting here: the web deployment owns the credentials.
 
 import {
+  REASONING_SUPPRESSION_ATTEMPTS,
   SEGMENTATION_GEMINI_GENERATION_CONFIG,
   SEGMENTATION_JSON_SCHEMA,
   SEGMENTATION_MAX_OUTPUT_TOKENS,
@@ -140,6 +141,9 @@ const extractContentText = (message) => {
   return null;
 };
 
+/** Remembers the successful suppression rung per endpoint and model. */
+const reasoningAttemptCache = new Map();
+
 const exhaustedByReasoning = (choice, usage) => {
   const reasoningTokens = usage?.completion_tokens_details?.reasoning_tokens;
   const hasReasoning = Boolean(reasoningTokens || choice?.message?.reasoning_content);
@@ -190,7 +194,7 @@ const sendOpenAICompatible = async (apiUrl, apiKey, body, fetchImpl) => {
   return { ok: true, choice, usage: data.usage, content: extractContentText(choice && choice.message) };
 };
 
-/** One bounded completion with shared HTTP capability fallbacks. */
+/** Original segmentation suppression ladder, with HTTP capability fallbacks inside each rung. */
 const runOpenAICompatible = async (lines, env, fetchImpl) => {
   const apiUrl = normalizeOpenAIChatCompletionsUrl(env.OPENAI_API_URL);
   const model = resolveOpenAICompatibleModel(apiUrl, env.OPENAI_API_MODEL);
@@ -210,16 +214,48 @@ const runOpenAICompatible = async (lines, env, fetchImpl) => {
     }
     : { type: 'json_object' };
 
-  const result = await sendOpenAICompatible(apiUrl, env.OPENAI_API_KEY, {
-    model,
-    messages,
-    temperature,
-    [provider === 'openai' ? 'max_completion_tokens' : 'max_tokens']: SEGMENTATION_MAX_OUTPUT_TOKENS,
-    response_format: responseFormat,
-  }, fetchImpl);
-  if (!result.ok) throw new SegmentationRequestError(result.errorText, 502);
-  if (result.content) return result.content;
-  throw new SegmentationRequestError(describeEmpty(result.choice, result.usage, model), 502);
+  const cacheKey = `${apiUrl}|${model}`;
+  const learned = reasoningAttemptCache.get(cacheKey);
+  const firstIndex = typeof learned === 'number' ? learned : 0;
+
+  let lastEmpty = null;
+  for (let index = firstIndex; index < REASONING_SUPPRESSION_ATTEMPTS.length; index += 1) {
+    const { params } = REASONING_SUPPRESSION_ATTEMPTS[index];
+    const isLastAttempt = index === REASONING_SUPPRESSION_ATTEMPTS.length - 1;
+    const budget = isLastAttempt ? SEGMENTATION_MAX_OUTPUT_TOKENS * 4 : SEGMENTATION_MAX_OUTPUT_TOKENS;
+
+    const result = await sendOpenAICompatible(apiUrl, env.OPENAI_API_KEY, {
+      model,
+      messages,
+      temperature,
+      [provider === 'openai' ? 'max_completion_tokens' : 'max_tokens']: budget,
+      ...params,
+      response_format: responseFormat,
+    }, fetchImpl);
+
+    if (!result.ok) {
+      if (!isLastAttempt && Object.keys(params).some(key => rejectsParameter(result.status, result.errorText, key))) {
+        continue;
+      }
+      throw new SegmentationRequestError(result.errorText, 502);
+    }
+
+    if (result.content) {
+      reasoningAttemptCache.set(cacheKey, index);
+      return result.content;
+    }
+
+    lastEmpty = result;
+    if (!isLastAttempt && exhaustedByReasoning(result.choice, result.usage)) {
+      continue;
+    }
+    break;
+  }
+
+  throw new SegmentationRequestError(
+    describeEmpty(lastEmpty?.choice, lastEmpty?.usage, model),
+    502,
+  );
 };
 
 const runGemini = async (lines, env, fetchImpl) => {

--- a/shared/lyricSegmentationService.mjs
+++ b/shared/lyricSegmentationService.mjs
@@ -1,3 +1,4 @@
+import { fetchOpenAICompatible } from './openAICompatibility.mjs';
 // shared/lyricSegmentationService.mjs
 // Server-side lyric word segmentation, shared by the Vercel edge handler and the Cloudflare
 // Worker. Those two runtimes differ only in where the environment comes from, so they are thin
@@ -8,7 +9,6 @@
 // build there is no user-facing setting here: the web deployment owns the credentials.
 
 import {
-  REASONING_SUPPRESSION_ATTEMPTS,
   SEGMENTATION_GEMINI_GENERATION_CONFIG,
   SEGMENTATION_JSON_SCHEMA,
   SEGMENTATION_MAX_OUTPUT_TOKENS,
@@ -89,10 +89,6 @@ const resolveOpenAICompatibleModel = (apiUrl, configuredModel) => {
 };
 
 const detectOpenAICompatibleProvider = (apiUrl, model) => {
-  const normalizedModel = model.trim().toLowerCase();
-  if (normalizedModel.startsWith('deepseek-')) {
-    return 'deepseek';
-  }
   try {
     const hostname = new URL(apiUrl).hostname.toLowerCase();
     if (hostname === 'api.deepseek.com' || hostname.endsWith('.deepseek.com')) {
@@ -103,9 +99,6 @@ const detectOpenAICompatibleProvider = (apiUrl, model) => {
     }
   } catch {
     // Fall through to generic provider handling.
-  }
-  if (/^(gpt|o[1-9]|o[1-9]-|chatgpt-)/.test(normalizedModel)) {
-    return 'openai';
   }
   return 'generic';
 };
@@ -147,14 +140,6 @@ const extractContentText = (message) => {
   return null;
 };
 
-/** Remembers the working request shape per endpoint+model, so probing is paid once per instance. */
-const reasoningAttemptCache = new Map();
-
-const rejectsParameters = (errorText, params) => {
-  const message = String(errorText).toLowerCase();
-  return Object.keys(params).some((key) => message.includes(key.toLowerCase()));
-};
-
 const exhaustedByReasoning = (choice, usage) => {
   const reasoningTokens = usage?.completion_tokens_details?.reasoning_tokens;
   const hasReasoning = Boolean(reasoningTokens || choice?.message?.reasoning_content);
@@ -178,12 +163,12 @@ const describeEmpty = (choice, usage, model) => {
 const sendOpenAICompatible = async (apiUrl, apiKey, body, fetchImpl) => {
   let response;
   try {
-    response = await fetchImpl(apiUrl, {
+    response = await fetchOpenAICompatible(apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
       body: JSON.stringify(body),
       signal: timeoutSignal(DEFAULT_AI_TIMEOUT_MS),
-    });
+    }, detectOpenAICompatibleProvider(apiUrl, body.model), fetchImpl);
   } catch (error) {
     if (isAbort(error)) {
       throw new SegmentationRequestError(`Request to ${apiUrl} timed out`, 504);
@@ -205,11 +190,7 @@ const sendOpenAICompatible = async (apiUrl, apiKey, body, fetchImpl) => {
   return { ok: true, choice, usage: data.usage, content: extractContentText(choice && choice.message) };
 };
 
-/**
- * Walks REASONING_SUPPRESSION_ATTEMPTS instead of assuming what the deployment configured. The
- * base URL and model are env, so they can name anything; the working shape is discovered and then
- * cached. See the ladder's definition for the measurements behind it.
- */
+/** One bounded completion with shared HTTP capability fallbacks. */
 const runOpenAICompatible = async (lines, env, fetchImpl) => {
   const apiUrl = normalizeOpenAIChatCompletionsUrl(env.OPENAI_API_URL);
   const model = resolveOpenAICompatibleModel(apiUrl, env.OPENAI_API_MODEL);
@@ -229,48 +210,16 @@ const runOpenAICompatible = async (lines, env, fetchImpl) => {
     }
     : { type: 'json_object' };
 
-  const cacheKey = `${apiUrl}|${model}`;
-  const learned = reasoningAttemptCache.get(cacheKey);
-  const firstIndex = typeof learned === 'number' ? learned : 0;
-
-  let lastEmpty = null;
-  for (let index = firstIndex; index < REASONING_SUPPRESSION_ATTEMPTS.length; index += 1) {
-    const { params } = REASONING_SUPPRESSION_ATTEMPTS[index];
-    const isLastAttempt = index === REASONING_SUPPRESSION_ATTEMPTS.length - 1;
-    const budget = isLastAttempt ? SEGMENTATION_MAX_OUTPUT_TOKENS * 4 : SEGMENTATION_MAX_OUTPUT_TOKENS;
-
-    const result = await sendOpenAICompatible(apiUrl, env.OPENAI_API_KEY, {
-      model,
-      messages,
-      temperature,
-      max_tokens: budget,
-      ...params,
-      response_format: responseFormat,
-    }, fetchImpl);
-
-    if (!result.ok) {
-      if (!isLastAttempt && (result.status === 400 || result.status === 422) && rejectsParameters(result.errorText, params)) {
-        continue;
-      }
-      throw new SegmentationRequestError(result.errorText, 502);
-    }
-
-    if (result.content) {
-      reasoningAttemptCache.set(cacheKey, index);
-      return result.content;
-    }
-
-    lastEmpty = result;
-    if (!isLastAttempt && exhaustedByReasoning(result.choice, result.usage)) {
-      continue;
-    }
-    break;
-  }
-
-  throw new SegmentationRequestError(
-    describeEmpty(lastEmpty?.choice, lastEmpty?.usage, model),
-    502,
-  );
+  const result = await sendOpenAICompatible(apiUrl, env.OPENAI_API_KEY, {
+    model,
+    messages,
+    temperature,
+    [provider === 'openai' ? 'max_completion_tokens' : 'max_tokens']: SEGMENTATION_MAX_OUTPUT_TOKENS,
+    response_format: responseFormat,
+  }, fetchImpl);
+  if (!result.ok) throw new SegmentationRequestError(result.errorText, 502);
+  if (result.content) return result.content;
+  throw new SegmentationRequestError(describeEmpty(result.choice, result.usage, model), 502);
 };
 
 const runGemini = async (lines, env, fetchImpl) => {

--- a/shared/openAICompatibility.mjs
+++ b/shared/openAICompatibility.mjs
@@ -1,0 +1,37 @@
+// Shared HTTP compatibility policy for Electron, Vercel and Worker requests.
+const unsupportedFormats = new Set();
+
+export function rejectsParameter(status, text, parameter) {
+  return status === 400
+    && /unsupported|not supported|does not support|invalid (?:parameter|argument)|unknown (?:parameter|argument)|unrecognized|not allowed/i.test(text)
+    && text.toLowerCase().includes(parameter.toLowerCase())
+    && !/rate.?limit|concurrency|quota/i.test(text);
+}
+
+export async function fetchOpenAICompatible(apiUrl, init, provider, fetchImpl = fetch) {
+  const body = JSON.parse(init.body);
+  // DeepSeek documents this switch; custom hosts are not assumed to implement it.
+  // https://api-docs.deepseek.com/guides/thinking_mode/
+  if (provider === 'deepseek') body.thinking = { type: 'disabled' };
+  const cacheKey = JSON.stringify([apiUrl, body.model]);
+  if (provider !== 'openai' && unsupportedFormats.has(cacheKey)) delete body.response_format;
+  // Each retry removes one explicitly rejected capability. Successful/transport errors never retry.
+  for (;;) {
+    const response = await fetchImpl(apiUrl, { ...init, body: JSON.stringify(body) });
+    if (response.ok || provider === 'openai' || response.status !== 400) return response;
+    const text = await response.text();
+    if (body.response_format && (rejectsParameter(400, text, 'response_format')
+      || rejectsParameter(400, text, 'json_schema'))) {
+      delete body.response_format;
+      unsupportedFormats.add(cacheKey);
+      console.info('[ai] endpoint rejected response_format; retrying without it');
+    } else if (body.max_tokens !== undefined && rejectsParameter(400, text, 'max_tokens')) {
+      body.max_completion_tokens = body.max_tokens;
+      delete body.max_tokens;
+      console.info('[ai] endpoint rejected max_tokens; retrying with max_completion_tokens');
+    } else {
+      // Keep an explicit output bound if neither token spelling is supported.
+      return new Response(text, { status: response.status, statusText: response.statusText });
+    }
+  }
+}

--- a/shared/openAICompatibility.mjs
+++ b/shared/openAICompatibility.mjs
@@ -1,11 +1,26 @@
 // Shared HTTP compatibility policy for Electron, Vercel and Worker requests.
 const unsupportedFormats = new Set();
+const unsupportedThinking = new Set();
+
+export function resetOpenAICompatibilityCache() {
+  unsupportedFormats.clear();
+  unsupportedThinking.clear();
+}
 
 export function rejectsParameter(status, text, parameter) {
-  return status === 400
-    && /unsupported|not supported|does not support|invalid (?:parameter|argument)|unknown (?:parameter|argument)|unrecognized|not allowed/i.test(text)
-    && text.toLowerCase().includes(parameter.toLowerCase())
-    && !/rate.?limit|concurrency|quota/i.test(text);
+  if ((status !== 400 && status !== 422) || /rate.?limit|concurrency|quota/i.test(text)) return false;
+  // Pydantic validation loc identifies the rejected field; input may contain unrelated fields.
+  try {
+    const payload = JSON.parse(text.replace(/^OpenAI compatible API error \(\d+\):\s*/, ''));
+    if (Array.isArray(payload.detail)) {
+      return payload.detail.some(issue => Array.isArray(issue.loc) && issue.loc.includes(parameter)
+        && (issue.type === 'extra_forbidden' || /extra inputs are not permitted/i.test(issue.msg || '')));
+    }
+  } catch {
+    // Plain-text gateways report the field and rejection together.
+  }
+  return /unsupported|not supported|does not support|invalid (?:parameter|argument)|unknown (?:parameter|argument)|unrecognized|not allowed|extra inputs are not permitted|extra_forbidden/i.test(text)
+    && new RegExp(`\\b${parameter}\\b`, 'i').test(text);
 }
 
 export async function fetchOpenAICompatible(apiUrl, init, provider, fetchImpl = fetch) {
@@ -15,17 +30,22 @@ export async function fetchOpenAICompatible(apiUrl, init, provider, fetchImpl = 
   if (provider === 'deepseek') body.thinking = { type: 'disabled' };
   const cacheKey = JSON.stringify([apiUrl, body.model]);
   if (provider !== 'openai' && unsupportedFormats.has(cacheKey)) delete body.response_format;
+  if (unsupportedThinking.has(cacheKey)) delete body.thinking;
   // Each retry removes one explicitly rejected capability. Successful/transport errors never retry.
   for (;;) {
     const response = await fetchImpl(apiUrl, { ...init, body: JSON.stringify(body) });
-    if (response.ok || provider === 'openai' || response.status !== 400) return response;
+    if (response.ok || provider === 'openai' || (response.status !== 400 && response.status !== 422)) return response;
     const text = await response.text();
-    if (body.response_format && (rejectsParameter(400, text, 'response_format')
-      || rejectsParameter(400, text, 'json_schema'))) {
+    if (body.response_format && (rejectsParameter(response.status, text, 'response_format')
+      || rejectsParameter(response.status, text, 'json_schema'))) {
       delete body.response_format;
       unsupportedFormats.add(cacheKey);
       console.info('[ai] endpoint rejected response_format; retrying without it');
-    } else if (body.max_tokens !== undefined && rejectsParameter(400, text, 'max_tokens')) {
+    } else if (body.thinking && rejectsParameter(response.status, text, 'thinking')) {
+      delete body.thinking;
+      unsupportedThinking.add(cacheKey);
+      console.info('[ai] endpoint rejected thinking; retrying without it');
+    } else if (body.max_tokens !== undefined && rejectsParameter(response.status, text, 'max_tokens')) {
       body.max_completion_tokens = body.max_tokens;
       delete body.max_tokens;
       console.info('[ai] endpoint rejected max_tokens; retrying with max_completion_tokens');

--- a/test/unit/lyrics/aiTextClientReasoning.test.ts
+++ b/test/unit/lyrics/aiTextClientReasoning.test.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { describe, expect, it, vi } from 'vitest';
+import { REASONING_SUPPRESSION_ATTEMPTS } from '../../../shared/lyricSegmentationPrompt.mjs';
 
 // test/unit/lyrics/aiTextClientReasoning.test.ts
 // Reasoning models were the worst failure in this feature: on Gemini they turned a request into
@@ -53,21 +54,83 @@ const run = (fetchImpl: unknown, url = 'http://endpoint.test/v1') => client.runA
     sourcePrompt: 'src',
     customFetch: fetchImpl,
     maxTokens: 4096,
+    disableReasoning: true,
 });
 
-describe('reasoning capabilities', () => {
-    it('does not guess reasoning parameters on generic endpoints', async () => {
+describe('reasoning suppression ladder', () => {
+    it('tries to switch reasoning off before anything else', async () => {
         const { attempts, fetchImpl } = makeFetch(() => answered('{}'));
-        await run(fetchImpl);
+        await run(fetchImpl, 'http://a.test/v1');
+
+        expect(attempts).toHaveLength(1);
+        expect(attempts[0].body).toMatchObject(REASONING_SUPPRESSION_ATTEMPTS[0].params);
+    });
+
+    it('walks down when the endpoint rejects the parameter, and still succeeds', async () => {
+        const { attempts, fetchImpl } = makeFetch((body) => {
+            if (body.reasoning_effort !== undefined) return rejected('reasoning_effort');
+            if (body.chat_template_kwargs !== undefined) return rejected('chat_template_kwargs');
+            return answered('{"ok":1}');
+        });
+
+        await expect(run(fetchImpl, 'http://b.test/v1')).resolves.toBe('{"ok":1}');
+        expect(attempts).toHaveLength(REASONING_SUPPRESSION_ATTEMPTS.length);
+        expect(attempts[attempts.length - 1].body.reasoning_effort).toBeUndefined();
+    });
+
+    it('walks down when the parameter is accepted but the model reasons anyway', async () => {
+        const { attempts, fetchImpl } = makeFetch((body, attempt) => (
+            attempt < 2 ? reasonedItself_dry(Number(body.max_tokens)) : answered('{"ok":1}')
+        ));
+
+        await expect(run(fetchImpl, 'http://c.test/v1')).resolves.toBe('{"ok":1}');
+        expect(attempts).toHaveLength(3);
+    });
+
+    it('gives the last attempt room for reasoning and an answer', async () => {
+        const { attempts, fetchImpl } = makeFetch((body, attempt) => (
+            attempt < 2 ? reasonedItself_dry(Number(body.max_tokens)) : answered('{}')
+        ));
+        await run(fetchImpl, 'http://d.test/v1');
+
+        expect(attempts[0].body.max_tokens).toBe(4096);
+        expect(attempts[2].body.max_tokens).toBeGreaterThan(4096);
+    });
+
+    it('remembers what worked, so later calls do not re-probe', async () => {
+        const { attempts, fetchImpl } = makeFetch((body) => (
+            body.reasoning_effort !== undefined ? rejected('reasoning_effort') : answered('{}')
+        ));
+        const url = 'http://e.test/v1';
+
+        await run(fetchImpl, url);
+        const afterFirst = attempts.length;
+        expect(afterFirst).toBeGreaterThan(1);
+
+        await run(fetchImpl, url);
+        expect(attempts.length - afterFirst).toBe(1);
+    });
+
+    it('does not walk the ladder for a real error, which would triple the failure', async () => {
+        const { attempts, fetchImpl } = makeFetch(() => ({
+            status: 401,
+            payload: { error: { message: 'Incorrect API key provided' } },
+        }));
+
+        await expect(run(fetchImpl, 'http://f.test/v1')).rejects.toThrow('Incorrect API key');
+        expect(attempts).toHaveLength(1);
+    });
+
+    it('sends nothing extra when the caller has not asked to disable reasoning', async () => {
+        const { attempts, fetchImpl } = makeFetch(() => answered('{}'));
+        await client.runAiJsonCompletion({
+            store: { get: (k: string) => ({ AI_PROVIDER: 'openai', OPENAI_API_KEY: 'k', OPENAI_API_URL: 'http://g.test/v1' }[k]) },
+            systemPrompt: 'sys', sourcePrompt: 'src', customFetch: fetchImpl, maxTokens: 4096,
+        });
+
         expect(attempts).toHaveLength(1);
         expect(attempts[0].body.reasoning_effort).toBeUndefined();
         expect(attempts[0].body.chat_template_kwargs).toBeUndefined();
-    });
-    it('uses the documented DeepSeek switch', async () => {
-        const { attempts, fetchImpl } = makeFetch(() => answered('{}'));
-        await run(fetchImpl, 'https://api.deepseek.com/v1');
-        expect(attempts).toHaveLength(1);
-        expect(attempts[0].body.thinking).toEqual({ type: 'disabled' });
     });
 });
 

--- a/test/unit/lyrics/aiTextClientReasoning.test.ts
+++ b/test/unit/lyrics/aiTextClientReasoning.test.ts
@@ -164,3 +164,59 @@ describe('request body', () => {
         expect(body.messages).toHaveLength(2);
     });
 });
+
+describe('OpenAI-compatible provider detection', () => {
+    it('treats GPT models on custom domains as generic', () => {
+        expect(client.detectOpenAICompatibleProvider('http://poc.megalinkware.com:21041/v1', 'gpt-5.6-luna'))
+            .toBe('generic');
+    });
+
+    it('treats api.openai.com and its subdomains as OpenAI', () => {
+        expect(client.detectOpenAICompatibleProvider('https://api.openai.com/v1', 'custom-model')).toBe('openai');
+        expect(client.detectOpenAICompatibleProvider('https://edge.api.openai.com/v1', 'custom-model')).toBe('openai');
+    });
+});
+
+describe('AI JSON response parsing', () => {
+    it.each([
+        ['pure JSON', '{"ok":true}'],
+        ['fenced JSON', '```json\n{"ok":true}\n```'],
+        ['prose-wrapped JSON', 'Here is the result:\n{"ok":true}\nDone.'],
+    ])('parses %s', (_label, input) => {
+        expect(client.parseAiJsonObject(input)).toEqual({ ok: true });
+    });
+
+    it('fails clearly when no valid JSON object exists', () => {
+        expect(() => client.parseAiJsonObject('No JSON was returned.'))
+            .toThrow('AI response did not contain a valid JSON object');
+    });
+
+    it('does not accept a syntactically valid object missing required fields', () => {
+        expect(() => client.parseAiJsonObject('{"ok":true}', ['light', 'dark']))
+            .toThrow('required keys: light, dark');
+    });
+});
+
+describe('generic JSON mode compatibility', () => {
+    it('retries once without response_format when JSON mode returns empty content', async () => {
+        const { attempts, fetchImpl } = makeFetch((_body, attempt) => (
+            attempt === 0 ? answered('') : answered('{"ok":true}')
+        ));
+
+        await expect(run(fetchImpl, 'http://generic-empty.test/v1')).resolves.toBe('{"ok":true}');
+        expect(attempts).toHaveLength(2);
+        expect(attempts[0].body.response_format).toEqual({ type: 'json_object' });
+        expect(attempts[1].body.response_format).toBeUndefined();
+    });
+
+    it('retries once without response_format for the gateway concurrency error', async () => {
+        const { attempts, fetchImpl } = makeFetch((_body, attempt) => attempt === 0 ? ({
+            status: 429,
+            payload: { error: { message: 'Concurrency limit exceeded for user, please retry later' } },
+        }) : answered('{"ok":true}'));
+
+        await expect(run(fetchImpl, 'http://generic-429.test/v1')).resolves.toBe('{"ok":true}');
+        expect(attempts).toHaveLength(2);
+        expect(attempts[1].body.response_format).toBeUndefined();
+    });
+});

--- a/test/unit/lyrics/aiTextClientReasoning.test.ts
+++ b/test/unit/lyrics/aiTextClientReasoning.test.ts
@@ -1,16 +1,11 @@
 import { createRequire } from 'node:module';
 import { describe, expect, it, vi } from 'vitest';
-import { REASONING_SUPPRESSION_ATTEMPTS } from '../../../shared/lyricSegmentationPrompt.mjs';
 
 // test/unit/lyrics/aiTextClientReasoning.test.ts
 // Reasoning models were the worst failure in this feature: on Gemini they turned a request into
 // 40s, and on DeepSeek they consumed the whole token budget and returned nothing at all after 52s.
 //
-// The user can point the app at any OpenAI-compatible URL with any model name, so there is no
-// provider list to key off. The client instead walks a ladder of ways to ask for no reasoning and
-// remembers what worked. These tests pin that walk, including the two conditions that advance it
-// and the one that must not.
-
+// Requests use endpoint capabilities; empty output and rate limits must not cause paid retries.
 const client = createRequire(import.meta.url)('../../../electron/aiTextClient.cjs');
 
 type Attempt = { body: Record<string, unknown> };
@@ -58,83 +53,21 @@ const run = (fetchImpl: unknown, url = 'http://endpoint.test/v1') => client.runA
     sourcePrompt: 'src',
     customFetch: fetchImpl,
     maxTokens: 4096,
-    disableReasoning: true,
 });
 
-describe('reasoning suppression ladder', () => {
-    it('tries to switch reasoning off before anything else', async () => {
+describe('reasoning capabilities', () => {
+    it('does not guess reasoning parameters on generic endpoints', async () => {
         const { attempts, fetchImpl } = makeFetch(() => answered('{}'));
-        await run(fetchImpl, 'http://a.test/v1');
-
-        expect(attempts).toHaveLength(1);
-        expect(attempts[0].body).toMatchObject(REASONING_SUPPRESSION_ATTEMPTS[0].params);
-    });
-
-    it('walks down when the endpoint rejects the parameter, and still succeeds', async () => {
-        const { attempts, fetchImpl } = makeFetch((body) => {
-            if (body.reasoning_effort !== undefined) return rejected('reasoning_effort');
-            if (body.chat_template_kwargs !== undefined) return rejected('chat_template_kwargs');
-            return answered('{"ok":1}');
-        });
-
-        await expect(run(fetchImpl, 'http://b.test/v1')).resolves.toBe('{"ok":1}');
-        expect(attempts).toHaveLength(REASONING_SUPPRESSION_ATTEMPTS.length);
-        expect(attempts[attempts.length - 1].body.reasoning_effort).toBeUndefined();
-    });
-
-    it('walks down when the parameter is accepted but the model reasons anyway', async () => {
-        const { attempts, fetchImpl } = makeFetch((body, attempt) => (
-            attempt < 2 ? reasonedItself_dry(Number(body.max_tokens)) : answered('{"ok":1}')
-        ));
-
-        await expect(run(fetchImpl, 'http://c.test/v1')).resolves.toBe('{"ok":1}');
-        expect(attempts).toHaveLength(3);
-    });
-
-    it('gives the last attempt room for reasoning and an answer', async () => {
-        const { attempts, fetchImpl } = makeFetch((body, attempt) => (
-            attempt < 2 ? reasonedItself_dry(Number(body.max_tokens)) : answered('{}')
-        ));
-        await run(fetchImpl, 'http://d.test/v1');
-
-        expect(attempts[0].body.max_tokens).toBe(4096);
-        expect(attempts[2].body.max_tokens).toBeGreaterThan(4096);
-    });
-
-    it('remembers what worked, so later calls do not re-probe', async () => {
-        const { attempts, fetchImpl } = makeFetch((body) => (
-            body.reasoning_effort !== undefined ? rejected('reasoning_effort') : answered('{}')
-        ));
-        const url = 'http://e.test/v1';
-
-        await run(fetchImpl, url);
-        const afterFirst = attempts.length;
-        expect(afterFirst).toBeGreaterThan(1);
-
-        await run(fetchImpl, url);
-        expect(attempts.length - afterFirst).toBe(1);
-    });
-
-    it('does not walk the ladder for a real error, which would triple the failure', async () => {
-        const { attempts, fetchImpl } = makeFetch(() => ({
-            status: 401,
-            payload: { error: { message: 'Incorrect API key provided' } },
-        }));
-
-        await expect(run(fetchImpl, 'http://f.test/v1')).rejects.toThrow('Incorrect API key');
-        expect(attempts).toHaveLength(1);
-    });
-
-    it('sends nothing extra when the caller has not asked to disable reasoning', async () => {
-        const { attempts, fetchImpl } = makeFetch(() => answered('{}'));
-        await client.runAiJsonCompletion({
-            store: { get: (k: string) => ({ AI_PROVIDER: 'openai', OPENAI_API_KEY: 'k', OPENAI_API_URL: 'http://g.test/v1' }[k]) },
-            systemPrompt: 'sys', sourcePrompt: 'src', customFetch: fetchImpl, maxTokens: 4096,
-        });
-
+        await run(fetchImpl);
         expect(attempts).toHaveLength(1);
         expect(attempts[0].body.reasoning_effort).toBeUndefined();
         expect(attempts[0].body.chat_template_kwargs).toBeUndefined();
+    });
+    it('uses the documented DeepSeek switch', async () => {
+        const { attempts, fetchImpl } = makeFetch(() => answered('{}'));
+        await run(fetchImpl, 'https://api.deepseek.com/v1');
+        expect(attempts).toHaveLength(1);
+        expect(attempts[0].body.thinking).toEqual({ type: 'disabled' });
     });
 });
 
@@ -167,7 +100,7 @@ describe('request body', () => {
 
 describe('OpenAI-compatible provider detection', () => {
     it('treats GPT models on custom domains as generic', () => {
-        expect(client.detectOpenAICompatibleProvider('http://poc.megalinkware.com:21041/v1', 'gpt-5.6-luna'))
+        expect(client.detectOpenAICompatibleProvider('https://example.test/v1', 'gpt-5.6-luna'))
             .toBe('generic');
     });
 
@@ -198,25 +131,27 @@ describe('AI JSON response parsing', () => {
 });
 
 describe('generic JSON mode compatibility', () => {
-    it('retries once without response_format when JSON mode returns empty content', async () => {
-        const { attempts, fetchImpl } = makeFetch((_body, attempt) => (
-            attempt === 0 ? answered('') : answered('{"ok":true}')
-        ));
-
-        await expect(run(fetchImpl, 'http://generic-empty.test/v1')).resolves.toBe('{"ok":true}');
-        expect(attempts).toHaveLength(2);
-        expect(attempts[0].body.response_format).toEqual({ type: 'json_object' });
-        expect(attempts[1].body.response_format).toBeUndefined();
+    it('does not classify empty success as a capability failure', async () => {
+        const { attempts, fetchImpl } = makeFetch(() => answered(''));
+        await expect(run(fetchImpl, 'https://empty.example.test/v1')).rejects.toThrow('empty response');
+        expect(attempts).toHaveLength(1);
     });
 
-    it('retries once without response_format for the gateway concurrency error', async () => {
-        const { attempts, fetchImpl } = makeFetch((_body, attempt) => attempt === 0 ? ({
-            status: 429,
-            payload: { error: { message: 'Concurrency limit exceeded for user, please retry later' } },
-        }) : answered('{"ok":true}'));
+    it.each([429, 400])('does not retry concurrency errors (%s)', async (status) => {
+        const { attempts, fetchImpl } = makeFetch(() => ({ status,
+            payload: { error: { message: 'Concurrency limit exceeded for user' } },
+        }));
+        await expect(run(fetchImpl, 'https://concurrency.example.test/v1')).rejects.toThrow('Concurrency');
+        expect(attempts).toHaveLength(1);
+    });
 
-        await expect(run(fetchImpl, 'http://generic-429.test/v1')).resolves.toBe('{"ok":true}');
-        expect(attempts).toHaveLength(2);
+    it('retries explicit response_format rejection and remembers it', async () => {
+        const { attempts, fetchImpl } = makeFetch(body => body.response_format
+            ? rejected('response_format') : answered('{}'));
+        await run(fetchImpl, 'https://cache.example.test/v1');
+        await run(fetchImpl, 'https://cache.example.test/v1');
+        expect(attempts).toHaveLength(3);
         expect(attempts[1].body.response_format).toBeUndefined();
+        expect(attempts[2].body.response_format).toBeUndefined();
     });
 });

--- a/test/unit/lyrics/lyricSegmentationPrompt.test.ts
+++ b/test/unit/lyrics/lyricSegmentationPrompt.test.ts
@@ -25,6 +25,11 @@ describe('lyric segmentation prompt parity', () => {
         expect(cjs.buildSegmentationManualPrompt(LINES)).toBe(esm.buildSegmentationManualPrompt(LINES));
     });
 
+    it('shares the suppression ladder and token budget', () => {
+        expect(cjs.REASONING_SUPPRESSION_ATTEMPTS).toEqual(esm.REASONING_SUPPRESSION_ATTEMPTS);
+        expect(cjs.SEGMENTATION_MAX_OUTPUT_TOKENS).toBe(esm.SEGMENTATION_MAX_OUTPUT_TOKENS);
+    });
+
     it('shares one schema, name and delimiter', () => {
         expect(cjs.SEGMENTATION_JSON_SCHEMA).toEqual(esm.SEGMENTATION_JSON_SCHEMA);
         expect(cjs.SEGMENTATION_SCHEMA_NAME).toBe(esm.SEGMENTATION_SCHEMA_NAME);

--- a/test/unit/lyrics/openAICompatibilityReasoning.test.ts
+++ b/test/unit/lyrics/openAICompatibilityReasoning.test.ts
@@ -1,0 +1,130 @@
+import { createRequire } from 'node:module';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchOpenAICompatible, rejectsParameter, resetOpenAICompatibilityCache } from '../../../shared/openAICompatibility.mjs';
+import { segmentLyricLines } from '../../../shared/lyricSegmentationService.mjs';
+
+// Parameter rejection is independent of a successful but reasoning-exhausted completion.
+const client = createRequire(import.meta.url)('../../../electron/aiTextClient.cjs');
+const answer = () => Response.json({ choices: [{ finish_reason: 'stop', message: { content: '{"lines":[["hello"]]}' } }] });
+const dry = () => Response.json({ choices: [{ finish_reason: 'length', message: { content: '', reasoning_content: 'thinking' } }],
+    usage: { completion_tokens_details: { reasoning_tokens: 8192 } } });
+const reject = (parameter: string, status = 422) => Response.json({ detail: [
+    { type: 'extra_forbidden', loc: ['body', parameter], msg: 'Extra inputs are not permitted' },
+] }, { status });
+let id = 0;
+const harness = (reply: (body: any, index: number) => Response, url = `https://suppression-${id++}.example.test/v1`) => {
+    const bodies: any[] = [];
+    const env = { AI_PROVIDER: 'openai', OPENAI_API_KEY: 'test-key', OPENAI_API_URL: url, OPENAI_API_MODEL: 'test-model' };
+    const fetchImpl = vi.fn(async (_url: unknown, init: any) => {
+        const body = JSON.parse(init.body); bodies.push(body); return reply(body, bodies.length - 1);
+    });
+    return { env, bodies, fetchImpl };
+};
+beforeEach(resetOpenAICompatibilityCache);
+
+const runners = {
+    electron: (env: Record<string, string>, fetchImpl: any, disableReasoning = true) => client.runAiJsonCompletion({
+        store: { get: (key: string) => env[key] }, systemPrompt: 'JSON', sourcePrompt: 'hello',
+        schema: { type: 'object' }, schemaName: 'test', maxTokens: 8192, disableReasoning, customFetch: fetchImpl,
+    }),
+    'web/worker shared segmentation': (env: Record<string, string>, fetchImpl: any) => segmentLyricLines(['hello'], env, fetchImpl),
+};
+for (const [name, run] of Object.entries(runners)) describe(name, () => {
+    it('restores the 8192, 8192, 32768 reasoning budget sequence', async () => {
+        const { env, bodies, fetchImpl } = harness((_body, i) => i < 2 ? dry() : answer());
+        await run(env, fetchImpl);
+        expect(bodies.map(b => b.max_tokens)).toEqual([8192, 8192, 32768]);
+        expect(bodies[0].reasoning_effort).toBe('none');
+        expect(bodies[1].chat_template_kwargs).toEqual({ enable_thinking: false });
+        expect(bodies[2].reasoning_effort).toBeUndefined();
+        expect(bodies[2].chat_template_kwargs).toBeUndefined();
+        expect(bodies.every(b => b.response_format)).toBe(true);
+    });
+    it('keeps HTTP fallback within the current suppression rung', async () => {
+        const { env, bodies, fetchImpl } = harness(body => {
+            if (body.response_format) return reject('response_format');
+            if (body.reasoning_effort) return reject('reasoning_effort');
+            return answer();
+        });
+        await run(env, fetchImpl);
+        expect(bodies).toHaveLength(3);
+        expect(bodies[1].reasoning_effort).toBe('none');
+        expect(bodies[1].response_format).toBeUndefined();
+        expect(bodies[2].chat_template_kwargs).toEqual({ enable_thinking: false });
+        expect(bodies[2].response_format).toBeUndefined();
+        await run(env, fetchImpl);
+        expect(bodies).toHaveLength(4);
+        expect(bodies[3]).toEqual(bodies[2]);
+    });
+    it('preserves official token spelling throughout suppression fallback', async () => {
+        const { env, bodies, fetchImpl } = harness(body => body.reasoning_effort
+            ? reject('reasoning_effort') : answer(), 'https://api.openai.com/v1');
+        env.OPENAI_API_MODEL = `official-${id++}`;
+        await run(env, fetchImpl);
+        expect(bodies).toHaveLength(2);
+        expect(bodies.every(b => !b.max_tokens && b.max_completion_tokens === 8192)).toBe(true);
+        expect(bodies.every(b => b.response_format.type === 'json_schema')).toBe(true);
+    });
+    it('remembers a rejected DeepSeek thinking parameter across suppression rungs', async () => {
+        const { env, bodies, fetchImpl } = harness(body => {
+            if (body.thinking) return reject('thinking');
+            if (body.reasoning_effort) return dry();
+            return answer();
+        }, 'https://api.deepseek.com/v1');
+        env.OPENAI_API_MODEL = `deepseek-${id++}`;
+        await run(env, fetchImpl);
+        expect(bodies).toHaveLength(3);
+        expect(bodies[0].thinking).toEqual({ type: 'disabled' });
+        expect(bodies.slice(1).every(b => !b.thinking)).toBe(true);
+        await run(env, fetchImpl);
+        expect(bodies).toHaveLength(4);
+        expect(bodies[3].thinking).toBeUndefined();
+    });
+    it.each([400, 422, 429, 503])('never retries a concurrency failure (%s)', async status => {
+        const { env, bodies, fetchImpl } = harness(() => Response.json({ error: { message: 'Concurrency limit exceeded: reasoning_effort' } }, { status }));
+        await expect(run(env, fetchImpl)).rejects.toThrow('Concurrency');
+        expect(bodies).toHaveLength(1);
+    });
+    it('does not retry empty content without reasoning exhaustion', async () => {
+        const { env, bodies, fetchImpl } = harness(() => Response.json({ choices: [{ finish_reason: 'stop', message: { content: '' } }] }));
+        await expect(run(env, fetchImpl)).rejects.toThrow('empty response');
+        expect(bodies).toHaveLength(1);
+    });
+});
+
+it('a theme completion does not overwrite the segmentation suppression cache', async () => {
+    const { env, bodies, fetchImpl } = harness(body => body.reasoning_effort ? reject('reasoning_effort') : answer());
+    await runners.electron(env, fetchImpl);
+    await runners.electron(env, fetchImpl, false);
+    await runners.electron(env, fetchImpl);
+    expect(bodies).toHaveLength(4);
+    expect(bodies[2].reasoning_effort).toBeUndefined();
+    expect(bodies[2].chat_template_kwargs).toBeUndefined();
+    expect(bodies[3].chat_template_kwargs).toEqual({ enable_thinking: false });
+});
+
+it.each([400, 422])('caches DeepSeek thinking rejection by endpoint/model and supports reset (%s)', async status => {
+    const { bodies, fetchImpl } = harness(body => body.thinking ? reject('thinking', status) : answer());
+    const send = (url = 'https://proxy.example.test/v1', model = 'deepseek-test') => fetchOpenAICompatible(url,
+        { body: JSON.stringify({ model, max_tokens: 8192, response_format: { type: 'json_object' } }) }, 'deepseek', fetchImpl);
+    await send(); await send();
+    expect(bodies).toHaveLength(3);
+    expect(bodies[2].thinking).toBeUndefined();
+    await send(undefined, 'other-model');
+    expect(bodies).toHaveLength(5);
+    await send('https://other.example.test/v1');
+    expect(bodies).toHaveLength(7);
+    resetOpenAICompatibilityCache(); await send();
+    expect(bodies).toHaveLength(9);
+    expect(bodies[7].thinking).toEqual({ type: 'disabled' });
+});
+
+it('recognizes Pydantic rejection without treating echoed input as the rejected field', () => {
+    const text = JSON.stringify({ detail: [{ type: 'extra_forbidden', msg: 'Extra inputs are not permitted',
+        loc: ['body', 'thinking'], input: { response_format: { type: 'json_object' } } }] });
+    expect(rejectsParameter(422, text, 'thinking')).toBe(true);
+    expect(rejectsParameter(422, text, 'response_format')).toBe(false);
+    expect(rejectsParameter(422, `OpenAI compatible API error (422): ${text}`, 'response_format')).toBe(false);
+    expect(rejectsParameter(422, 'type=extra_forbidden loc=response_format', 'response_format')).toBe(true);
+    expect(rejectsParameter(422, 'unsupported chat_template_kwargs', 'thinking')).toBe(false);
+});

--- a/test/unit/theme/openAICompatibility.test.ts
+++ b/test/unit/theme/openAICompatibility.test.ts
@@ -75,7 +75,7 @@ for (const [name, run] of Object.entries(routes)) describe(name, () => {
         expect(bodies[0].response_format.type).toBe('json_object');
         expect(bodies[0].max_tokens).toBe(8192);
         expect(bodies[0].thinking).toBeUndefined();
-        expect(bodies[0].reasoning_effort).toBeUndefined();
+        expect(bodies[0].reasoning_effort).toBe(name.includes('segmentation') ? 'none' : undefined);
     });
     it.each(['response_format not supported', "Unsupported parameter: response_format", 'unsupported json_schema'])('falls back for %s', async message => {
         const { env, bodies } = setup(undefined, undefined, (_, index) => index === 0 ? rejected(message) : undefined);

--- a/test/unit/theme/openAICompatibility.test.ts
+++ b/test/unit/theme/openAICompatibility.test.ts
@@ -1,0 +1,114 @@
+import { createRequire } from 'node:module';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import apiTheme from '../../../api-ts/generate-theme_openai';
+import generatedTheme from '../../../api/generate-theme_openai.js';
+import { handleGenerateOpenAITheme } from '../../../worker/generate-theme_openai';
+import apiSegments from '../../../api-ts/segment-lyrics';
+import { handleSegmentLyrics } from '../../../worker/segment-lyrics';
+
+// Exercise actual adapters, not just the shared retry predicate.
+const client = createRequire(import.meta.url)('../../../electron/aiTextClient.cjs');
+const theme = { name: 'test', description: 'test', backgroundColor: '#ffffff', primaryColor: '#111111',
+    accentColor: '#ff0000', secondaryColor: '#555555', wordColors: [], lyricsIcons: [] };
+const content = JSON.stringify({ light: theme, dark: theme, lines: [['hello']] });
+type Env = Record<string, string>;
+const request = () => new Request('https://app.example.test', { method: 'POST',
+    body: JSON.stringify({ lyricsText: 'hello', lines: ['hello'] }) });
+const routes = {
+    'web theme': (env: Env) => apiTheme(request()),
+    'generated web theme': (env: Env) => generatedTheme(request()),
+    'worker theme': (env: Env) => handleGenerateOpenAITheme(request(), env),
+    'web segmentation': (env: Env) => apiSegments(request()),
+    'worker segmentation': (env: Env) => handleSegmentLyrics(request(), env),
+    'electron': async (env: Env) => {
+        try {
+            await client.runAiJsonCompletion({ store: { get: (key: string) => env[key] },
+                systemPrompt: 'JSON', sourcePrompt: 'hello', schema: { type: 'object' }, schemaName: 'test',
+                maxTokens: 8192, customFetch: globalThis.fetch });
+            return new Response('{}');
+        } catch (error) { return new Response(String(error), { status: 500 }); }
+    },
+};
+let sequence = 0;
+const setup = (url?: string, model = 'gpt-5.6-luna', reply?: (body: Record<string, any>, index: number) => Response | undefined) => {
+    const env = { AI_PROVIDER: 'openai', OPENAI_API_KEY: 'test-key', OPENAI_API_URL: url || `https://case-${sequence++}.example.test/v1`, OPENAI_API_MODEL: model };
+    for (const [key, value] of Object.entries(env)) vi.stubEnv(key, value);
+    const bodies: any[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (_url, init) => {
+        const body = JSON.parse(init.body);
+        bodies.push(body);
+        return reply?.(body, bodies.length - 1) || Response.json({ choices: [{ message: { content } }] });
+    }));
+    return { env, bodies };
+};
+afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals(); });
+const rejected = (message: string, status = 400) => Response.json({ error: { message } }, { status });
+
+for (const [name, run] of Object.entries(routes)) describe(name, () => {
+    it('uses official defaults when endpoint and model are unset', async () => {
+        const { env, bodies } = setup();
+        env.OPENAI_API_URL = ''; env.OPENAI_API_MODEL = '';
+        vi.stubEnv('OPENAI_API_URL', ''); vi.stubEnv('OPENAI_API_MODEL', '');
+        expect((await run(env)).status).toBe(200);
+        expect(bodies[0].model).toBe('gpt-5.6-luna');
+        expect(bodies[0].max_tokens).toBeUndefined();
+        expect(bodies[0].max_completion_tokens).toBeGreaterThan(0);
+    });
+    it('does not remove the output bound if both token parameters are rejected', async () => {
+        const { env, bodies } = setup(undefined, undefined, body =>
+            rejected('Unsupported parameter: ' + (body.max_tokens ? 'max_tokens' : 'max_completion_tokens')));
+        expect((await run(env)).status).toBeGreaterThanOrEqual(400);
+        expect(bodies).toHaveLength(2);
+        expect(bodies.every(body => body.max_tokens || body.max_completion_tokens)).toBe(true);
+    });
+    it.each(['gpt-5.6-luna', 'o3'])('uses official token and schema parameters for %s', async model => {
+        const { env, bodies } = setup('https://api.openai.com/v1', model);
+        expect((await run(env)).status).toBe(200);
+        expect(bodies).toHaveLength(1);
+        expect(bodies[0].max_tokens).toBeUndefined();
+        expect(bodies[0].max_completion_tokens).toBeGreaterThan(0);
+        expect(bodies[0].response_format.type).toBe('json_schema');
+    });
+    it.each(['gpt-5.6-luna', 'deepseek-reasoner'])('does not infer official capabilities from %s', async model => {
+        const { env, bodies } = setup(undefined, model);
+        expect((await run(env)).status).toBe(200);
+        expect(bodies[0].response_format.type).toBe('json_object');
+        expect(bodies[0].max_tokens).toBe(8192);
+        expect(bodies[0].thinking).toBeUndefined();
+        expect(bodies[0].reasoning_effort).toBeUndefined();
+    });
+    it.each(['response_format not supported', "Unsupported parameter: response_format", 'unsupported json_schema'])('falls back for %s', async message => {
+        const { env, bodies } = setup(undefined, undefined, (_, index) => index === 0 ? rejected(message) : undefined);
+        expect((await run(env)).status).toBe(200);
+        expect(bodies).toHaveLength(2);
+        expect(bodies[1].response_format).toBeUndefined();
+        expect(bodies[1].max_tokens).toBe(8192);
+    });
+    it.each([429, 500, 400])('does not classify rate limiting as a capability (%s)', async status => {
+        const { env, bodies } = setup(undefined, undefined, () => rejected('Concurrency limit exceeded: response_format not supported', status));
+        expect((await run(env)).status).toBeGreaterThanOrEqual(400);
+        expect(bodies).toHaveLength(1);
+    });
+    it('never applies generic fallback to official OpenAI', async () => {
+        const { env, bodies } = setup('https://api.openai.com/v1', undefined, () => rejected('response_format not supported'));
+        expect((await run(env)).status).toBeGreaterThanOrEqual(400);
+        expect(bodies).toHaveLength(1);
+    });
+    it('switches the rejected token spelling while preserving the bound', async () => {
+        const { env, bodies } = setup(undefined, undefined, body => body.max_tokens ? rejected('Invalid parameter: max_tokens') : undefined);
+        expect((await run(env)).status).toBe(200);
+        expect(bodies).toHaveLength(2);
+        expect(bodies[1].max_tokens).toBeUndefined();
+        expect(bodies[1].max_completion_tokens).toBe(8192);
+    });
+    it('does not guess another shape after a network failure', async () => {
+        const { env, bodies } = setup(undefined, undefined, () => { throw new Error('network failed'); });
+        expect((await run(env)).status).toBeGreaterThanOrEqual(400);
+        expect(bodies).toHaveLength(1);
+    });
+});
+
+it('bounds pathological JSON candidate scanning', () => {
+    expect(() => client.parseAiJsonObject('{'.repeat(65536))).toThrow('valid JSON object');
+    expect(client.parseAiJsonObject('prefix {bad} then {"ok":true}')).toEqual({ ok: true });
+});

--- a/worker/generate-theme_openai.ts
+++ b/worker/generate-theme_openai.ts
@@ -12,6 +12,7 @@ const DEFAULT_OPENAI_MODEL = 'gpt-5.6-luna';
 const DEFAULT_OPENAI_TEMPERATURE = 0.7;
 const DEEPSEEK_DEFAULT_MODEL = 'deepseek-v4-flash';
 const THEME_JSON_SCHEMA_NAME = 'dual_theme';
+const THEME_MAX_OUTPUT_TOKENS = 4096;
 
 const THEME_JSON_SCHEMA = {
     type: 'object',
@@ -150,10 +151,6 @@ const detectOpenAICompatibleProvider = (apiUrl: string, model: string): OpenAICo
         // Fall through to generic provider handling.
     }
 
-    if (/^(gpt|o[1-9]|o[1-9]-|chatgpt-)/.test(normalizedModel)) {
-        return 'openai';
-    }
-
     return 'generic';
 };
 
@@ -278,6 +275,7 @@ const buildOpenAICompatibleRequestBody = (
             model,
             messages,
             temperature,
+            max_tokens: THEME_MAX_OUTPUT_TOKENS,
             response_format: {
                 type: 'json_schema',
                 json_schema: {
@@ -293,6 +291,7 @@ const buildOpenAICompatibleRequestBody = (
         model,
         messages,
         temperature,
+        max_tokens: THEME_MAX_OUTPUT_TOKENS,
         response_format: { type: 'json_object' }
     };
 };
@@ -320,6 +319,39 @@ const extractResponseContentText = (message: { content?: unknown; refusal?: unkn
     }
 
     return null;
+};
+
+const parseAiJsonObject = (input: string, requiredKeys: string[] = []): Record<string, unknown> => {
+    const text = input.trim();
+    for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+        let depth = 0;
+        let inString = false;
+        let escaped = false;
+        for (let index = start; index < text.length; index += 1) {
+            const char = text[index];
+            if (inString) {
+                if (escaped) escaped = false;
+                else if (char === '\\') escaped = true;
+                else if (char === '"') inString = false;
+                continue;
+            }
+            if (char === '"') inString = true;
+            else if (char === '{') depth += 1;
+            else if (char === '}' && --depth === 0) {
+                try {
+                    const parsed: unknown = JSON.parse(text.slice(start, index + 1));
+                    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                        && requiredKeys.every((key) => Object.hasOwn(parsed, key))) {
+                        return parsed as Record<string, unknown>;
+                    }
+                } catch {
+                    break;
+                }
+            }
+        }
+    }
+    const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+    throw new Error(`AI response did not contain a valid JSON object${requirement}`);
 };
 
 export async function handleGenerateOpenAITheme(request: Request, env: WorkerEnv) {
@@ -381,20 +413,11 @@ export async function handleGenerateOpenAITheme(request: Request, env: WorkerEnv
             throw new Error('Failed to generate theme JSON');
         }
 
-        // Attempt to parse JSON
         let dualTheme;
-        let jsonStr = content.trim();
-
-        // Remove markdown code blocks if present
-        if (jsonStr.startsWith('```')) {
-            jsonStr = jsonStr.replace(/^```(json)?\n/, '').replace(/\n```$/, '');
-        }
-
         try {
-            dualTheme = sanitizeDualTheme(JSON.parse(jsonStr));
+            dualTheme = sanitizeDualTheme(parseAiJsonObject(content, ['light', 'dark']));
         } catch (e) {
-            console.error('Failed to parse JSON from AI response:', jsonStr);
-            throw new Error('Invalid JSON response from AI');
+            throw new Error(`Invalid JSON response from AI: ${e instanceof Error ? e.message : String(e)}`);
         }
 
         // Force fixed properties for both themes

--- a/worker/generate-theme_openai.ts
+++ b/worker/generate-theme_openai.ts
@@ -1,3 +1,4 @@
+import { fetchOpenAICompatible } from '../shared/openAICompatibility.mjs';
 import { sanitizeDualTheme } from '../shared/themeSanitizer.mjs';
 
 type WorkerEnv = {
@@ -134,10 +135,6 @@ const resolveOpenAICompatibleModel = (apiUrl: string, configuredModel?: string) 
 };
 
 const detectOpenAICompatibleProvider = (apiUrl: string, model: string): OpenAICompatibleProvider => {
-    const normalizedModel = model.trim().toLowerCase();
-    if (normalizedModel.startsWith('deepseek-')) {
-        return 'deepseek';
-    }
 
     try {
         const hostname = new URL(apiUrl).hostname.toLowerCase();
@@ -275,7 +272,7 @@ const buildOpenAICompatibleRequestBody = (
             model,
             messages,
             temperature,
-            max_tokens: THEME_MAX_OUTPUT_TOKENS,
+            max_completion_tokens: THEME_MAX_OUTPUT_TOKENS,
             response_format: {
                 type: 'json_schema',
                 json_schema: {
@@ -291,7 +288,7 @@ const buildOpenAICompatibleRequestBody = (
         model,
         messages,
         temperature,
-        max_tokens: THEME_MAX_OUTPUT_TOKENS,
+        max_tokens: 8192,
         response_format: { type: 'json_object' }
     };
 };
@@ -323,11 +320,13 @@ const extractResponseContentText = (message: { content?: unknown; refusal?: unkn
 
 const parseAiJsonObject = (input: string, requiredKeys: string[] = []): Record<string, unknown> => {
     const text = input.trim();
-    for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+    // Bound malformed-input scanning; normal theme objects fit comfortably within this limit.
+    let candidates = 0;
+    for (let start = text.indexOf('{'); start !== -1 && candidates++ < 64; start = text.indexOf('{', start + 1)) {
         let depth = 0;
         let inString = false;
         let escaped = false;
-        for (let index = start; index < text.length; index += 1) {
+        for (let index = start; index < Math.min(text.length, start + 131072); index += 1) {
             const char = text[index];
             if (inString) {
                 if (escaped) escaped = false;
@@ -351,6 +350,7 @@ const parseAiJsonObject = (input: string, requiredKeys: string[] = []): Record<s
         }
     }
     const requirement = requiredKeys.length ? ` with required keys: ${requiredKeys.join(', ')}` : '';
+    console.error('[ai] invalid JSON response:', JSON.stringify({ length: text.length, preview: text.slice(0, 512).replace(/sk-[a-zA-Z0-9_-]+|Bearer\s+[^\s"']+/g, '[redacted]') }));
     throw new Error(`AI response did not contain a valid JSON object${requirement}`);
 };
 
@@ -389,14 +389,15 @@ export async function handleGenerateOpenAITheme(request: Request, env: WorkerEnv
         const systemPrompt = buildThemeSystemPrompt(true);
         const sourcePrompt = buildThemeSourcePrompt(snippet, isPureMusic, songTitle);
 
-        const response = await fetch(apiUrl, {
+        const response = await fetchOpenAICompatible(apiUrl, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 Authorization: `Bearer ${apiKey}`,
             },
             body: JSON.stringify(buildOpenAICompatibleRequestBody(model, provider, systemPrompt, sourcePrompt, temperature)),
-        });
+            signal: AbortSignal.timeout(120_000),
+        }, provider);
 
         if (!response.ok) {
             const errorMessage = await formatOpenAICompatibleError(response);


### PR DESCRIPTION
## 问题

自定义 OpenAI-compatible endpoint 即使使用 `gpt-*` 等模型名，也不一定支持官方 OpenAI 的 Structured Outputs。原先依据模型名推断 provider 会发送不受支持的参数；主题请求还会向官方 OpenAI 发送不适用的 `max_tokens`。

## 当前实现

### Endpoint 与 token 参数

- OpenAI-compatible 的 provider/capability 判断以 endpoint hostname 为核心，不再凭 `gpt-*`、`o*`、`chatgpt-*` 或 `deepseek-*` 模型名认定 provider。Gemini 仍使用独立调用路径。
- 官方 OpenAI 使用 `max_completion_tokens`，并保留 `json_schema`；不进入 generic HTTP 参数兼容分支。
- 兼容端初始使用 `max_tokens`，被明确拒绝时改用 `max_completion_tokens`，保留相同预算。两种写法均被拒绝时明确报错，不静默移除上限。
- 主题保留当前显式预算：官方 OpenAI 4096，兼容端 8192。保留 120s timeout。

### 两套独立降级机制

**HTTP 参数能力降级**由 `shared/openAICompatibility.mjs` 统一处理：

- 仅在明确的 400/422 参数或能力拒绝时降级，包括 Pydantic `extra_forbidden` / `Extra inputs are not permitted` 与 `loc` 字段定位。
- `response_format` / `json_schema` 被明确拒绝时，移除 `response_format` 后重试。
- DeepSeek 的 `thinking: { type: 'disabled' }` 被明确拒绝时，移除字段后重试。
- 不支持 `response_format`、`thinking` 的结果按 endpoint + model 在进程/实例内缓存，提供 reset 入口，不跨会话持久化。
- 空正文、429、并发/限流错误、网络失败不触发 HTTP compatibility fallback。

**Reasoning suppression**恢复 main 原有歌词分词行为：

- `reasoning_effort: 'none'` → `chat_template_kwargs: { enable_thinking: false }` → 不带 suppression 参数。
- 当前 suppression 参数被明确拒绝，或成功响应没有正文、以 `length` 结束且存在 reasoning 耗尽证据时，才进入下一档；成功档位会被缓存。
- Electron 与 Web/Worker 分词恢复最终 4× token budget：8192 → 8192 → 32768。官方路径各档均使用正确的 token 参数。
- HTTP 参数降级发生在当前 suppression 档位内部，二者不混用触发条件。
- 根据 main 的实际历史，主题生成不启用分词 suppression 链；主题调用也不会覆盖分词的成功档位缓存。

### 其他

- 保留 fenced/prose-wrapped JSON 提取，校验主题 `light` / `dark` 结构；限制解析扫描候选数与长度，保留有限的响应诊断摘要。
- 保持 `.mjs` / `.cjs` prompt 孪生定义一致，无新增依赖或配置格式变更。

## 验证与边界

- 本次独立提交完整单测：3397 通过、1 项既有跳过。
- TypeScript 类型检查通过；相关测试覆盖官方请求体、两层降级、400/422、DeepSeek thinking 拒绝、缓存隔离/reset、reasoning 耗尽与 32768 兜底。
- 本地 `npm run build`、Electron 语法检查及 `git diff --check` 通过；5 个生成的 API 文件与 api-ts 重新编译结果逐字节一致。
- 仓库没有 lint 脚本。构建保留大 chunk 与 npm 既有配置警告。
- 本轮验证使用 mock HTTP 和实际 client/handler 路径，没有执行新的真实付费 API 联调，也未验证 Electron GUI。
- 32768 是恢复 main 的既有最终兜底，不代表所有模型支持该上限；本 PR 不猜测模型最大预算或新增无上限重试。
