### PR TITLE
fix(kugou): 修复酷狗歌曲收藏行为以及修复linux图标

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "folia-major",
   "productName": "Folia",
+  "desktopName": "folia-major.desktop",
   "description": "Lyrics Reimagine",
   "author": {
     "name": "chthollyphile",
@@ -187,7 +188,8 @@
       },
       "icon": "build/icon.png",
       "category": "AudioVideo",
-      "executableName": "folia-major"
+      "executableName": "folia-major",
+      "syncDesktopName": true
     }
   },
   "dependencies": {

--- a/packaging/aur/folia-major-bin/folia-major.desktop
+++ b/packaging/aur/folia-major-bin/folia-major.desktop
@@ -6,4 +6,4 @@ Icon=folia-major
 Terminal=false
 Type=Application
 Categories=AudioVideo;Player;
-StartupWMClass=Folia
+StartupWMClass=folia-major

--- a/packaging/linux/folia-major.desktop
+++ b/packaging/linux/folia-major.desktop
@@ -6,4 +6,4 @@ Icon=__ICON_PATH__
 Terminal=false
 Type=Application
 Categories=AudioVideo;Player;
-StartupWMClass=Folia
+StartupWMClass=folia-major

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -947,6 +947,7 @@ export default function App() {
         addCurrentSongToLocalPlaylist,
         createCurrentLocalPlaylist,
         addCurrentSongToOnlinePlaylist,
+        createCurrentOnlinePlaylist,
         addCurrentSongToNavidromePlaylist,
         createCurrentNavidromePlaylist,
         loadCurrentSongLyricPreview,
@@ -2743,6 +2744,7 @@ export default function App() {
                 onAddCurrentSongToLocalPlaylist={addCurrentSongToLocalPlaylist}
                 onCreateCurrentLocalPlaylist={createCurrentLocalPlaylist}
                 onAddCurrentSongToOnlinePlaylist={addCurrentSongToOnlinePlaylist}
+                onCreateCurrentOnlinePlaylist={createCurrentOnlinePlaylist}
                 onAddCurrentSongToNavidromePlaylist={addCurrentSongToNavidromePlaylist}
                 onCreateCurrentNavidromePlaylist={createCurrentNavidromePlaylist}
             />

--- a/src/components/app/AddToPlaylistHost.tsx
+++ b/src/components/app/AddToPlaylistHost.tsx
@@ -27,6 +27,7 @@ type AddToPlaylistHostProps = {
     onAddCurrentSongToLocalPlaylist: (playlistId: string) => Promise<void>;
     onCreateCurrentLocalPlaylist: (name: string) => Promise<void>;
     onAddCurrentSongToOnlinePlaylist: (playlist: ProviderCollection) => Promise<void>;
+    onCreateCurrentOnlinePlaylist: (name: string) => Promise<void>;
     onAddCurrentSongToNavidromePlaylist: (playlistId: string) => Promise<void>;
     onCreateCurrentNavidromePlaylist: (name: string) => Promise<void>;
 };
@@ -40,6 +41,7 @@ export const AddToPlaylistHost: React.FC<AddToPlaylistHostProps> = ({
     onAddCurrentSongToLocalPlaylist,
     onCreateCurrentLocalPlaylist,
     onAddCurrentSongToOnlinePlaylist,
+    onCreateCurrentOnlinePlaylist,
     onAddCurrentSongToNavidromePlaylist,
     onCreateCurrentNavidromePlaylist,
 }) => {
@@ -114,9 +116,11 @@ export const AddToPlaylistHost: React.FC<AddToPlaylistHostProps> = ({
     }, [isLocal, isOnline, isNavidrome, localPlaylists, navidromePlaylists, onlinePlaylists, t]);
 
     const isApplicable = Boolean(currentSong && !isStage && (isLocal || isOnline || isNavidrome));
-    // Local and Navidrome can make a playlist on the spot, so having none is not a refusal there.
+    const canCreateOnline = Boolean(isOnline && currentSong && omni.canCreatePlaylist(currentSong));
+    // Local, Navidrome and capable online providers can create a playlist on the spot, so having
+    // none is not a refusal there.
     const canAdd = (isLocal)
-        || (isOnline && canAddOnlineSong && onlinePlaylists.length > 0)
+        || (isOnline && canAddOnlineSong && (onlinePlaylists.length > 0 || canCreateOnline))
         || (isNavidrome);
     const disabledReason = isOnline && !canAddOnlineSong
         ? t('status.providerPlaylistMutationUnavailable', { provider: onlineProviderLabel })
@@ -163,8 +167,9 @@ export const AddToPlaylistHost: React.FC<AddToPlaylistHostProps> = ({
                         await refreshNavidromePlaylists();
                     }
                 }}
-                onCreate={(isLocal || isNavidrome) ? () => {
-                    close();
+                onCreate={(isLocal || isNavidrome || canCreateOnline) ? () => {
+                    // Keep the selection dialog mounted behind the name prompt so the refreshed
+                    // playlist list is immediately selectable after creation.
                     setIsCreateOpen(true);
                 } : undefined}
                 createLabel={t(isNavidrome ? 'navidrome.createPlaylist' : 'localMusic.createPlaylist')}
@@ -181,6 +186,11 @@ export const AddToPlaylistHost: React.FC<AddToPlaylistHostProps> = ({
                 onConfirm={async (name) => {
                     if (isLocal) {
                         await onCreateCurrentLocalPlaylist(name);
+                        return;
+                    }
+
+                    if (isOnline) {
+                        await onCreateCurrentOnlinePlaylist(name);
                         return;
                     }
 

--- a/src/components/app/player-panel/usePlayerPanelModel.ts
+++ b/src/components/app/player-panel/usePlayerPanelModel.ts
@@ -9,6 +9,7 @@ import { useThemeSettingsStore } from '../../../stores/useThemeSettingsStore';
 import { useAudioSettingsStore } from '../../../stores/useAudioSettingsStore';
 import { useVisualizerSettingsStore } from '../../../stores/useVisualizerSettingsStore';
 import { usePlayerChromeSettingsStore } from '../../../stores/usePlayerChromeSettingsStore';
+import { useOnlineProviderAccountStore } from '../../../stores/useOnlineProviderAccountStore';
 import { selectDisplayCoverUrl, selectDisplayLyrics, usePlaybackStore } from '../../../stores/usePlaybackStore';
 import type { LocalSong, SongResult } from '../../../types';
 import type { LocalLibraryCatalogSnapshot } from '../../../hooks/useLocalLibraryCatalog';
@@ -74,9 +75,19 @@ export const usePlayerPanelModel = ({
     const displayCoverUrl = usePlaybackStore(selectDisplayCoverUrl);
     const displayLyrics = usePlaybackStore(selectDisplayLyrics);
 
+    // `omni.isSongLiked` reads the provider account store, but this memo only re-runs when its
+    // dependencies change. Subscribe to the playing provider's liked set so a successful
+    // favorite/unfavorite immediately recomputes the heart icon for every online provider.
+    const currentSongProviderId = currentSong?.sourceRef?.kind === 'online'
+        ? currentSong.sourceRef.providerId
+        : undefined;
+    const providerLikedSongIds = useOnlineProviderAccountStore(state => (
+        currentSongProviderId ? state.accounts[currentSongProviderId]?.likedSongIds : undefined
+    ));
+
     const isLiked = useMemo(
         () => resolveSongLiked(currentSong, { isLocalSongLiked, starredNavidromeSongIds, likedSongIds }),
-        [currentSong, isLocalSongLiked, likedSongIds, starredNavidromeSongIds],
+        [currentSong, isLocalSongLiked, likedSongIds, starredNavidromeSongIds, providerLikedSongIds],
     );
 
     const collectionEntries = useMemo(() => createPlayerPanelCollectionEntries({

--- a/src/components/panelTab/controls/SongActionRow.tsx
+++ b/src/components/panelTab/controls/SongActionRow.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Heart, Repeat, Repeat1, RepeatOff, Sparkle, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ThemeSourceModel } from '../../../hooks/themeControllerState';
+import { openAddToPlaylist } from '../../../stores/useAddToPlaylistStore';
+
+const LIKE_LONG_PRESS_MS = 500;
 
 // src/components/panelTab/controls/SongActionRow.tsx
 // 当前歌曲的三个动作：循环、喜欢、生成 AI 主题。面板里唯一一排大触控目标，保持原样。
@@ -38,6 +41,50 @@ const SongActionRow: React.FC<SongActionRowProps> = ({
     const { t } = useTranslation();
     const loopButtonBg = isDaylight ? 'bg-black/5 hover:bg-zinc-300/85' : 'bg-white/5 hover:bg-white/10';
     const buttonBg = isDaylight ? 'bg-black/5 hover:bg-black/10' : 'bg-white/5 hover:bg-white/10';
+    const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const suppressLikeClickRef = useRef(false);
+
+    const clearLikeLongPress = () => {
+        if (longPressTimerRef.current !== null) {
+            clearTimeout(longPressTimerRef.current);
+            longPressTimerRef.current = null;
+        }
+    };
+
+    useEffect(() => () => clearLikeLongPress(), []);
+
+    const handleLikePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+        if (event.button !== 0 || likeDisabled) return;
+        suppressLikeClickRef.current = false;
+        clearLikeLongPress();
+        longPressTimerRef.current = setTimeout(() => {
+            longPressTimerRef.current = null;
+            // Keep the click after a long press from also toggling the song's liked state.
+            suppressLikeClickRef.current = true;
+            openAddToPlaylist();
+        }, LIKE_LONG_PRESS_MS);
+    };
+
+    const handleLikePointerUp = () => {
+        clearLikeLongPress();
+    };
+
+    const handleLikePointerLeave = () => {
+        clearLikeLongPress();
+    };
+
+    const handleLikePointerCancel = () => {
+        clearLikeLongPress();
+        suppressLikeClickRef.current = false;
+    };
+
+    const handleLikeClick = () => {
+        if (suppressLikeClickRef.current) {
+            suppressLikeClickRef.current = false;
+            return;
+        }
+        onLike();
+    };
 
     return (
         <div className="grid grid-cols-3 gap-3">
@@ -50,7 +97,11 @@ const SongActionRow: React.FC<SongActionRowProps> = ({
             </button>
 
             <button
-                onClick={onLike}
+                onClick={handleLikeClick}
+                onPointerDown={handleLikePointerDown}
+                onPointerUp={handleLikePointerUp}
+                onPointerLeave={handleLikePointerLeave}
+                onPointerCancel={handleLikePointerCancel}
                 disabled={likeDisabled}
                 title={likeDisabledReason || (isLiked ? t('player.unlike') : t('player.like'))}
                 aria-label={likeDisabledReason || (isLiked ? t('player.unlike') : t('player.like'))}

--- a/src/components/shared/PlaylistSelectionDialog.tsx
+++ b/src/components/shared/PlaylistSelectionDialog.tsx
@@ -50,20 +50,21 @@ const PlaylistSelectionDialog: React.FC<PlaylistSelectionDialogProps> = ({
             title={title}
             description={description}
             maxWidthClass="max-w-lg"
+            headerActions={onCreate ? (
+                <button
+                    type="button"
+                    onClick={onCreate}
+                    disabled={submittingId !== null}
+                    title={createLabel || t('localMusic.createPlaylist')}
+                    aria-label={createLabel || t('localMusic.createPlaylist')}
+                    className={`mr-4 inline-flex h-9 w-9 items-center justify-center rounded-full border transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${panelClass}`}
+                >
+                    <Plus size={16} />
+                </button>
+            ) : undefined}
         >
             {playlists.length > 0 ? (
                 <div className="space-y-3">
-                    {onCreate && (
-                        <button
-                            type="button"
-                            onClick={onCreate}
-                            disabled={submittingId !== null}
-                            className={`flex w-full items-center justify-center gap-2 rounded-2xl border border-dashed px-5 py-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${panelClass}`}
-                        >
-                            <Plus size={16} />
-                            {createLabel || t('localMusic.saveQueueAsPlaylist') || 'Create Playlist'}
-                        </button>
-                    )}
                     <div className="max-h-[320px] space-y-2 overflow-y-auto pr-1 custom-scrollbar">
                     {playlists.map((playlist) => (
                         <button
@@ -94,17 +95,6 @@ const PlaylistSelectionDialog: React.FC<PlaylistSelectionDialogProps> = ({
                 </div>
             ) : (
                 <div className="space-y-3">
-                    {onCreate && (
-                        <button
-                            type="button"
-                            onClick={onCreate}
-                            disabled={submittingId !== null}
-                            className={`flex w-full items-center justify-center gap-2 rounded-2xl border border-dashed px-5 py-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${panelClass}`}
-                        >
-                            <Plus size={16} />
-                            {createLabel || t('localMusic.saveQueueAsPlaylist') || 'Create Playlist'}
-                        </button>
-                    )}
                     <div className="rounded-2xl border border-dashed border-white/10 px-4 py-8 text-center text-sm opacity-50">
                         {t('localMusic.noPlaylistsFound') || 'No playlists yet'}
                     </div>

--- a/src/hooks/useLibraryPlaybackController.ts
+++ b/src/hooks/useLibraryPlaybackController.ts
@@ -323,6 +323,21 @@ export function useLibraryPlaybackController({
         setStatusMsg({ type: 'success', text: t('status.playlistUpdated') || '' });
     }, [currentSong, setStatusMsg, t]);
 
+    const createCurrentOnlinePlaylist = useCallback(async (name: string) => {
+        if (!currentSong) throw new Error('No current song');
+        if (!omni.canCreatePlaylist(currentSong)) {
+            const source = getPlaybackSourceRef(currentSong);
+            const provider = source.kind === 'online' ? omni.getProviderLabel(source.providerId) : '';
+            setStatusMsg({
+                type: 'info',
+                text: t('status.providerPlaylistMutationUnavailable').replace('{{provider}}', provider),
+            });
+            return;
+        }
+        await omni.createPlaylist(currentSong, name);
+        setStatusMsg({ type: 'success', text: t('status.playlistUpdated') || '' });
+    }, [currentSong, setStatusMsg, t]);
+
     const addCurrentSongToNavidromePlaylist = useCallback(async (playlistId: string) => {
         if (!isNavidromePlaybackSong(currentSong)) {
             throw new Error('Current song is not a Navidrome song');
@@ -1478,6 +1493,7 @@ export function useLibraryPlaybackController({
         addCurrentSongToLocalPlaylist,
         createCurrentLocalPlaylist,
         addCurrentSongToOnlinePlaylist,
+        createCurrentOnlinePlaylist,
         addCurrentSongToNavidromePlaylist,
         createCurrentNavidromePlaylist,
         resolveLocalMetadataUI,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2371,6 +2371,8 @@ export default {
   "player": {
     "unknownArtist": "Unknown Artist",
     "unknownAlbum": "Unknown Album",
+    "like": "Like",
+    "unlike": "Unlike",
   },
   "localMusic": {
     "foldersAndPlaylists": "Folders & Playlists",

--- a/src/i18n/locales/in.ts
+++ b/src/i18n/locales/in.ts
@@ -2304,7 +2304,9 @@ export default {
   },
   "player": {
     "unknownArtist": "Artis Tidak Dikenal",
-    "unknownAlbum": "Album Tidak Dikenal"
+    "unknownAlbum": "Album Tidak Dikenal",
+    "like": "Suka",
+    "unlike": "Tidak Suka"
   },
   "localMusic": {
     "foldersAndPlaylists": "Folder & Playlist",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -2370,6 +2370,8 @@ export default {
   "player": {
     "unknownArtist": "未知歌手",
     "unknownAlbum": "未知专辑",
+    "like": "收藏",
+    "unlike": "取消收藏",
   },
   "localMusic": {
     "foldersAndPlaylists": "文件夹",

--- a/src/services/onlineMusic/kugouProvider.ts
+++ b/src/services/onlineMusic/kugouProvider.ts
@@ -803,12 +803,18 @@ const getKugouPlaylistFallbackCover = async (rawPlaylist: any): Promise<string |
         .find((cover): cover is string => Boolean(cover));
 };
 
+const getKugouTrackHash = (track: MediaId | SongResult): string => {
+    if (typeof track !== 'object') return String(track).toUpperCase();
+    const sourceData = track.sourceRef?.kind === 'online' ? track.sourceRef.providerData : undefined;
+    return String(sourceData?.hash || track.kgHash || track.id).toUpperCase();
+};
+
 const getKugouTrackAddData = (track: MediaId | SongResult): string => {
     if (typeof track !== 'object') return `|${String(track).toUpperCase()}|0|0`;
     const sourceData = track.sourceRef?.kind === 'online' ? track.sourceRef.providerData : undefined;
     return [
         track.name,
-        String(sourceData?.hash || track.kgHash || track.id).toUpperCase(),
+        getKugouTrackHash(track),
         String(sourceData?.albumId || track.album?.id || 0),
         String(sourceData?.mixSongId || 0),
     ].join('|');
@@ -818,6 +824,27 @@ const getKugouTrackFileId = (track: MediaId | SongResult): string => {
     if (typeof track !== 'object') return String(track);
     const sourceData = track.sourceRef?.kind === 'online' ? track.sourceRef.providerData : undefined;
     return String(sourceData?.fileId || track.id);
+};
+
+const KUGOU_LIKED_TRACK_MAX_PAGES = 50;
+
+// KuGou's playlist entry `fileid` is local to one playlist, unlike the global audio hash. The
+// liked-song mutations must therefore look up the row id inside the liked playlist itself.
+const getKugouPlaylistTrackSongs = async (globalCollectionId: string): Promise<UnifiedSong[]> => {
+    const songs: UnifiedSong[] = [];
+    for (let page = 1; page <= KUGOU_LIKED_TRACK_MAX_PAGES; page += 1) {
+        const response = await requestKugou('playlist_track_all', {
+            id: globalCollectionId,
+            page,
+            pagesize: KUGOU_MAX_PAGE_SIZE,
+        });
+        const rawItems = listOf(response);
+        songs.push(...rawItems.map(normalizeKugouSong));
+        const total = Number(dataOf(response)?.count ?? dataOf(response)?.total ?? Number.NaN);
+        if (rawItems.length < KUGOU_MAX_PAGE_SIZE) break;
+        if (Number.isFinite(total) && songs.length >= total) break;
+    }
+    return songs;
 };
 
 const kugouHistoryNameByDate = new Map<string, string>();
@@ -1122,15 +1149,8 @@ export const kugouProvider: OnlineMusicProvider = {
             const playlist = await getKugouLikedPlaylist(userId);
             const globalCollectionId = valueOf(playlist, 'global_collection_id', 'globalCollectionId');
             if (!globalCollectionId) return [];
-            const response = await requestKugou('playlist_track_all', {
-                id: String(globalCollectionId),
-                page: 1,
-                pagesize: KUGOU_MAX_PAGE_SIZE,
-            });
-            return listOf(response)
-                .map(normalizeKugouSong)
-                .map(song => song.id)
-                .filter(Boolean);
+            const songs = await getKugouPlaylistTrackSongs(String(globalCollectionId));
+            return songs.map(song => song.id).filter(Boolean);
         },
     },
     catalog: {
@@ -1142,7 +1162,8 @@ export const kugouProvider: OnlineMusicProvider = {
 
             const requestLimit = Math.min(Math.max(1, limit), KUGOU_MAX_PAGE_SIZE);
             const response = await requestKugou('playlist_track_all', { id: String(id), pagesize: requestLimit, page: Math.floor(offset / requestLimit) + 1 });
-            return pageOf(listOf(response).map(normalizeKugouSong), response, requestLimit, offset);
+            const songs = listOf(response).map(normalizeKugouSong);
+            return pageOf(songs, response, requestLimit, offset);
         },
         async getCloudTracks(limit, offset) {
             const requestLimit = Math.min(Math.max(1, limit), KUGOU_MAX_PAGE_SIZE);
@@ -1316,6 +1337,20 @@ export const kugouProvider: OnlineMusicProvider = {
     },
     mutations: {
         canAddToPlaylist: canAddToKugouPlaylist,
+        async createPlaylist(name) {
+            const userId = getKugouUserId();
+            const trimmedName = name.trim();
+            if (!userId || !trimmedName) return;
+            // type 0 = create a new playlist (type 1 would collect an existing playlist).
+            await requestKugou('playlist_add', {
+                name: trimmedName,
+                type: 0,
+                source: 1,
+                list_create_userid: userId,
+                list_create_listid: '0',
+                is_pri: 0,
+            });
+        },
         async likeSong(song, liked) {
             const userId = getKugouUserId();
             if (!userId) return;
@@ -1329,9 +1364,26 @@ export const kugouProvider: OnlineMusicProvider = {
                 });
                 return;
             }
+
+            // The song's providerData.fileId belongs to the playlist it was played from. Looking it
+            // up in the liked playlist by hash is required; sending another playlist's row id deletes
+            // whichever liked song happens to share that id.
+            const globalCollectionId = valueOf(playlist, 'global_collection_id', 'globalCollectionId');
+            if (!globalCollectionId) return;
+            const targetHash = getKugouTrackHash(song);
+            const likedTracks = await getKugouPlaylistTrackSongs(String(globalCollectionId));
+            const likedTrack = likedTracks.find(track => getKugouTrackHash(track) === targetHash);
+            const likedFileId = likedTrack?.sourceRef?.kind === 'online'
+                ? likedTrack.sourceRef.providerData?.fileId
+                : undefined;
+            if (likedFileId === undefined || likedFileId === null || String(likedFileId) === '') {
+                console.warn('[KuGouProvider] unlike:file-id-not-found', { hash: targetHash });
+                return;
+            }
+
             await requestKugou('playlist_tracks_del', {
                 listid: String(listId),
-                fileids: getKugouTrackFileId(song),
+                fileids: String(likedFileId),
             });
         },
         async updatePlaylistTracks(operation, playlist, tracks) {

--- a/src/services/onlineMusic/omni.ts
+++ b/src/services/onlineMusic/omni.ts
@@ -295,6 +295,13 @@ export const omni = {
             && Boolean(provider?.mutations?.updatePlaylistTracks);
     },
 
+    canCreatePlaylist(song: SongResult): boolean {
+        const source = getPlaybackSourceRef(song);
+        if (source.kind !== 'online') return false;
+        const provider = getOnlineMusicProvider(source.providerId);
+        return providerSupports(provider, 'mutations') && Boolean(provider?.mutations?.createPlaylist);
+    },
+
     canLikeSong(song: SongResult): boolean {
         const source = getPlaybackSourceRef(song);
         if (source.kind !== 'online') return false;
@@ -540,6 +547,26 @@ export const omni = {
         } catch (error) {
             console.warn('[Omni] Failed to refresh provider playlists after mutation', {
                 providerId: playlist.providerId,
+                name: error instanceof Error ? error.name : 'Error',
+            });
+        }
+    },
+
+    async createPlaylist(song: SongResult, name: string): Promise<void> {
+        const source = getPlaybackSourceRef(song);
+        if (source.kind !== 'online') {
+            throw new OnlineProviderError('unsupported', 'Only online songs can create online playlists');
+        }
+        const provider = getOnlineMusicProvider(source.providerId);
+        if (!this.canCreatePlaylist(song) || !provider?.mutations?.createPlaylist) {
+            return unsupported(source.providerId, 'playlist-creation');
+        }
+        await provider.mutations.createPlaylist(name);
+        try {
+            await this.refreshProviderPlaylists(source.providerId);
+        } catch (error) {
+            console.warn('[Omni] Failed to refresh provider playlists after playlist creation', {
+                providerId: source.providerId,
                 name: error instanceof Error ? error.name : 'Error',
             });
         }

--- a/src/types/onlineMusic.ts
+++ b/src/types/onlineMusic.ts
@@ -307,6 +307,7 @@ export interface OnlineRecommendationProvider {
 
 export interface OnlineMutationProvider {
     canAddToPlaylist?(playlist: ProviderCollection): boolean;
+    createPlaylist?(name: string): Promise<void>;
     likeSong?(song: MediaId | SongResult, liked: boolean): Promise<void>;
     updatePlaylistTracks?(
         operation: 'add' | 'del',

--- a/test/unit/onlineMusic/kugouProvider.test.ts
+++ b/test/unit/onlineMusic/kugouProvider.test.ts
@@ -1200,12 +1200,76 @@ describe('kugouProvider', () => {
                     }],
                 },
             })
+            .mockResolvedValueOnce({
+                data: {
+                    count: 1,
+                    songs: [{
+                        hash: 'abc123',
+                        name: 'Song 1',
+                        fileid: 987,
+                    }],
+                },
+            })
             .mockResolvedValueOnce({});
         await kugouProvider.mutations?.likeSong?.(song, false);
 
-        expect(requestMock).toHaveBeenNthCalledWith(2, 'playlist_tracks_del', {
-            listid: '2', fileids: 'ABC123',
+        expect(requestMock).toHaveBeenNthCalledWith(2, 'playlist_track_all', {
+            id: 'collection_3_user_2_0', page: 1, pagesize: 100,
         });
+        expect(requestMock).toHaveBeenNthCalledWith(3, 'playlist_tracks_del', {
+            listid: '2', fileids: '987',
+        });
+    });
+
+    it('creates a new playlist through the documented playlist_add endpoint', async () => {
+        requestMock.mockResolvedValue({});
+
+        await kugouProvider.mutations?.createPlaylist?.('  New Playlist  ');
+
+        expect(requestMock).toHaveBeenCalledWith('playlist_add', {
+            name: 'New Playlist',
+            type: 0,
+            source: 1,
+            list_create_userid: 'web-session-user',
+            list_create_listid: '0',
+            is_pri: 0,
+        });
+    });
+
+    it('skips the liked-playlist delete when the unlike target is not present', async () => {
+        const song = normalizeKugouSong({
+            hash: 'abc123',
+            name: 'Song 1',
+            album_id: 12,
+            mixsongid: 34,
+        });
+        requestMock
+            .mockResolvedValueOnce({
+                data: {
+                    info: [{
+                        type: 0,
+                        source: 1,
+                        listid: 2,
+                        name: '我喜欢',
+                        global_collection_id: 'collection_3_user_2_0',
+                    }],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    count: 1,
+                    songs: [{
+                        hash: 'different-hash',
+                        name: 'Other Song',
+                        fileid: 42,
+                    }],
+                },
+            });
+
+        await kugouProvider.mutations?.likeSong?.(song, false);
+
+        expect(requestMock).toHaveBeenCalledTimes(2);
+        expect(requestMock).not.toHaveBeenCalledWith('playlist_tracks_del', expect.anything());
     });
 
     it('builds virtual playlists from KuGou song recommendation cards', async () => {


### PR DESCRIPTION
## 背景

本次修改包含四个独立问题：

1. Linux 下 Dock栏无法正确显示图标。
2. 酷狗在非“我喜欢”歌单中取消收藏时，会误删“我喜欢”歌单中的随机歌曲。
3. 酷狗收藏 / 取消收藏后，心形图标状态不刷新。
4. 希望长按收藏按钮可以选择歌单，同时支持在歌单选择窗口中新建歌单。


---

## 修改内容

### 1. 修复 Linux Dock 图标

- `package.json`
  - 增加 `desktopName: "folia-major.desktop"`。
  - `build.linux` 开启 `syncDesktopName: true`。
- `packaging/linux/folia-major.desktop`
  - `StartupWMClass` 从 `Folia` 改为 `folia-major`。
- `packaging/aur/folia-major-bin/folia-major.desktop`
  - `StartupWMClass` 从 `Folia` 改为 `folia-major`。

这样 `.desktop` 文件名、`StartupWMClass` 和 Electron 运行窗口的 `WM_CLASS` 保持一致，Dock 能正确关联并显示图标。

### 2. 修复酷狗取消收藏误删随机歌曲

根因：酷狗 `fileid` 是“歌单内行 ID”，不是全局歌曲 ID。原实现拿当前播放歌单歌曲的 `fileId` 去删除“我喜欢”歌单中对应`fileId` 的歌曲，导致相同 `fileid` 的另一首歌被误删。`fileId` 的逻辑：新建一个歌单时，该歌单的`fileId` 从1开始依次增长，删除歌曲时不重置。例如：新建歌单收藏了10首歌，`fileId` 为从1到10，全部删除后再添加10首，`fileId` 为从11到20。

修复：

- 取消收藏时读取“我喜欢”歌单的 `global_collection_id`。
- 分页读取“我喜欢”歌单全部歌曲。
- 按全局 `hash` 找到目标歌曲。
- 使用该歌曲在“我喜欢”歌单中的真实 `fileId` 调用 `/playlist/tracks/del`。
- 找不到目标时中止操作，不发送删除请求。

涉及文件：

- `src/services/onlineMusic/kugouProvider.ts`
- `test/unit/onlineMusic/kugouProvider.test.ts`

### 3. 修复收藏 / 取消收藏后图标不刷新

根因：`usePlayerPanelModel` 中的 `isLiked` 是 `useMemo` 计算的，但 `omni.isSongLiked` 实际读取在线账户 store 中的 `likedSongIds`，账户更新后 memo 依赖没有变化，导致图标状态陈旧。

修复：

- 订阅当前歌曲所属 provider 的 `likedSongIds`。
- 将其加入 `isLiked` 的 `useMemo` 依赖。
- 收藏 / 取消收藏成功后图标立即更新。

涉及文件：

- `src/components/app/player-panel/usePlayerPanelModel.ts`

### 4. 长按收藏按钮选择歌单

- `src/components/panelTab/controls/SongActionRow.tsx`
  - 点按：默认收藏 / 取消收藏到“我喜欢”。
  - 长按 500ms：打开歌单选择弹窗。
  - 长按后抑制随后的 click，避免同时触发默认收藏。

- `src/components/shared/PlaylistSelectionDialog.tsx`
  - 右上角新增 `+` 按钮，用于创建新歌单。

- `src/components/app/AddToPlaylistHost.tsx`
  - 新建歌单时不再关闭歌单选择窗口。
  - 创建完成后保持选择窗口打开，并刷新用户歌单列表。
  - 新歌单创建后可直接选择。

- `src/services/onlineMusic/kugouProvider.ts`
  - 新增 `createPlaylist`，调用酷狗 `/playlist/add`：
    - `type: 0` 表示新建歌单
    - `source: 1`
    - `list_create_userid: 当前用户 id`
    - `list_create_listid: '0'`
    - `is_pri: 0`

- `src/services/onlineMusic/omni.ts`
  - 新增 `canCreatePlaylist` 与 `createPlaylist` 统一入口。
  - 创建后自动 `refreshProviderPlaylists`。

- `src/hooks/useLibraryPlaybackController.ts`
  - 新增 `createCurrentOnlinePlaylist`。

- `src/App.tsx`
  - 将创建回调传给 `AddToPlaylistHost`。

- `src/types/onlineMusic.ts`
  - `OnlineMutationProvider` 新增 `createPlaylist?` 契约。

### 5. 收藏按钮提示文本修复

根级 `player` 翻译缺少 `like` / `unlike`，导致悬停显示 `player.like` / `player.unlike`。

已补：

- `src/i18n/locales/zh-CN.ts`
- `src/i18n/locales/en.ts`
- `src/i18n/locales/in.ts`

现在悬停显示：

- 未收藏：`收藏`
- 已收藏：`取消收藏`

---

## 新增 / 调整接口

酷狗：

- 新建歌单：`/playlist/add`，`type: 0`
- 收藏歌曲到歌单：`/playlist/tracks/add`
- 取消收藏：`/playlist/tracks/del`

---

## 验证

已通过：

```bash
npm run typecheck