### PR TITLE
fix: keep OBS health responses free of credentials

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3,6 +3,7 @@ const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const { spawn } = require('child_process');
+const { createObsBrowserSourceHttpHandler, sendObsJson } = require('./obsBrowserSourceHttp.cjs');
 const Store = require('electron-store').default || require('electron-store');
 const crypto = require('crypto');
 const { createStageApi } = require('./stageApi.cjs');
@@ -4257,15 +4258,6 @@ function getStaticContentType(filePath) {
   return 'application/octet-stream';
 }
 
-function sendObsJson(res, statusCode, payload) {
-  res.writeHead(statusCode, {
-    'Content-Type': 'application/json; charset=utf-8',
-    'Cache-Control': 'no-store',
-    'Access-Control-Allow-Origin': '*',
-  });
-  res.end(JSON.stringify(payload));
-}
-
 function sendObsText(res, statusCode, text, contentType = 'text/plain; charset=utf-8') {
   res.writeHead(statusCode, {
     'Content-Type': contentType,
@@ -4341,64 +4333,16 @@ async function serveObsStaticFile(req, res, pathname) {
   }
 }
 
-async function handleObsBrowserSourceHttpRequest(req, res) {
-  const requestUrl = new URL(req.url || '/', `http://127.0.0.1:${getConfiguredObsBrowserSourcePort()}`);
-  const pathname = requestUrl.pathname;
-
-  if (pathname === '/obs/health' && req.method === 'GET') {
-    sendObsJson(res, 200, buildObsBrowserSourceStatus());
-    return;
-  }
-
-  if (!isObsBrowserSourceEnabled()) {
-    sendObsJson(res, 503, { error: 'OBS browser source is disabled.' });
-    return;
-  }
-
-  if (pathname === '/obs/events' && req.method === 'GET') {
-    if (!matchesObsBrowserSourceToken(requestUrl)) {
-      sendObsJson(res, 401, { error: 'Unauthorized.' });
-      return;
-    }
-
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream; charset=utf-8',
-      'Cache-Control': 'no-store',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-      'Access-Control-Allow-Origin': '*',
-    });
-    res.write(': connected\n\n');
-    obsBrowserSourceClients.add(res);
-    sendObsBrowserSourceBootstrapEvents(res);
-    broadcastObsBrowserSourceStatus();
-
-    req.on('close', () => {
-      obsBrowserSourceClients.delete(res);
-      broadcastObsBrowserSourceStatus();
-    });
-    return;
-  }
-
-  if (pathname === '/obs' && req.method === 'GET') {
-    if (!matchesObsBrowserSourceToken(requestUrl)) {
-      sendObsJson(res, 401, { error: 'Unauthorized.' });
-      return;
-    }
-
-    if (isElectronDevRuntime()) {
-      const devUrl = new URL('http://localhost:3000');
-      devUrl.searchParams.set('obs', '1');
-      devUrl.searchParams.set('token', requestUrl.searchParams.get('token') || '');
-      devUrl.searchParams.set('obsPort', String(getConfiguredObsBrowserSourcePort()));
-      res.writeHead(302, { Location: devUrl.toString() });
-      res.end();
-      return;
-    }
-  }
-
-  await serveObsStaticFile(req, res, pathname);
-}
+const handleObsBrowserSourceHttpRequest = createObsBrowserSourceHttpHandler({
+  getConfiguredObsBrowserSourcePort,
+  isObsBrowserSourceEnabled,
+  obsBrowserSourceClients,
+  matchesObsBrowserSourceToken,
+  sendObsBrowserSourceBootstrapEvents,
+  broadcastObsBrowserSourceStatus,
+  isElectronDevRuntime,
+  serveObsStaticFile,
+});
 
 async function startObsBrowserSourceServerIfNeeded() {
   if (!isObsBrowserSourceEnabled()) {

--- a/electron/obsBrowserSourceHttp.cjs
+++ b/electron/obsBrowserSourceHttp.cjs
@@ -1,0 +1,88 @@
+// electron/obsBrowserSourceHttp.cjs
+// HTTP boundary for the desktop OBS browser source, independent of Electron startup.
+
+function sendObsJson(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'Access-Control-Allow-Origin': '*',
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function createObsBrowserSourceHttpHandler({
+  getConfiguredObsBrowserSourcePort,
+  isObsBrowserSourceEnabled,
+  obsBrowserSourceClients,
+  matchesObsBrowserSourceToken,
+  sendObsBrowserSourceBootstrapEvents,
+  broadcastObsBrowserSourceStatus,
+  isElectronDevRuntime,
+  serveObsStaticFile,
+}) {
+  return async function handleObsBrowserSourceHttpRequest(req, res) {
+    const requestUrl = new URL(req.url || '/', `http://127.0.0.1:${getConfiguredObsBrowserSourcePort()}`);
+    const pathname = requestUrl.pathname;
+
+    if (pathname === '/obs/health' && req.method === 'GET') {
+      // Health is public; the credential-bearing status belongs to the desktop IPC flow.
+      sendObsJson(res, 200, {
+        enabled: isObsBrowserSourceEnabled(),
+        port: getConfiguredObsBrowserSourcePort(),
+        clientCount: obsBrowserSourceClients.size,
+      });
+      return;
+    }
+
+    if (!isObsBrowserSourceEnabled()) {
+      sendObsJson(res, 503, { error: 'OBS browser source is disabled.' });
+      return;
+    }
+
+    if (pathname === '/obs/events' && req.method === 'GET') {
+      if (!matchesObsBrowserSourceToken(requestUrl)) {
+        sendObsJson(res, 401, { error: 'Unauthorized.' });
+        return;
+      }
+
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Cache-Control': 'no-store',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+        'Access-Control-Allow-Origin': '*',
+      });
+      res.write(': connected\n\n');
+      obsBrowserSourceClients.add(res);
+      sendObsBrowserSourceBootstrapEvents(res);
+      broadcastObsBrowserSourceStatus();
+
+      req.on('close', () => {
+        obsBrowserSourceClients.delete(res);
+        broadcastObsBrowserSourceStatus();
+      });
+      return;
+    }
+
+    if (pathname === '/obs' && req.method === 'GET') {
+      if (!matchesObsBrowserSourceToken(requestUrl)) {
+        sendObsJson(res, 401, { error: 'Unauthorized.' });
+        return;
+      }
+
+      if (isElectronDevRuntime()) {
+        const devUrl = new URL('http://localhost:3000');
+        devUrl.searchParams.set('obs', '1');
+        devUrl.searchParams.set('token', requestUrl.searchParams.get('token') || '');
+        devUrl.searchParams.set('obsPort', String(getConfiguredObsBrowserSourcePort()));
+        res.writeHead(302, { Location: devUrl.toString() });
+        res.end();
+        return;
+      }
+    }
+
+    await serveObsStaticFile(req, res, pathname);
+  };
+}
+
+module.exports = { createObsBrowserSourceHttpHandler, sendObsJson };

--- a/test/unit/electron/obsBrowserSourceHttp.test.ts
+++ b/test/unit/electron/obsBrowserSourceHttp.test.ts
@@ -1,0 +1,158 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// test/unit/electron/obsBrowserSourceHttp.test.ts
+// Exercise the actual HTTP handler without starting Electron or reading user settings.
+
+const { createObsBrowserSourceHttpHandler } = require('../../../electron/obsBrowserSourceHttp.cjs') as {
+    createObsBrowserSourceHttpHandler: (options: Record<string, unknown>) => (
+        req: http.IncomingMessage, res: http.ServerResponse,
+    ) => Promise<void>;
+};
+
+const activeServers: http.Server[] = [];
+
+afterEach(async () => {
+    await Promise.all(activeServers.splice(0).map(server => new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close(error => error ? reject(error) : resolve());
+    })));
+});
+
+const startServer = async ({ enabled = true, token = 'private-obs-token', dev = false }: {
+    enabled?: boolean;
+    token?: string | null;
+    dev?: boolean;
+} = {}) => {
+    let port = 0;
+    const clients = new Set<http.ServerResponse>();
+    const matchesToken = vi.fn((url: URL) => Boolean(token) && url.searchParams.get('token') === token);
+    const broadcastStatus = vi.fn();
+    const serveStaticFile = vi.fn(async (_req: http.IncomingMessage, res: http.ServerResponse) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html>OBS source</html>');
+    });
+    const handler = createObsBrowserSourceHttpHandler({
+        getConfiguredObsBrowserSourcePort: () => port,
+        isObsBrowserSourceEnabled: () => enabled,
+        obsBrowserSourceClients: clients,
+        matchesObsBrowserSourceToken: matchesToken,
+        sendObsBrowserSourceBootstrapEvents: (res: http.ServerResponse) => {
+            res.write('event: config\ndata: {"song":{"name":"Test song"}}\n\n');
+        },
+        broadcastObsBrowserSourceStatus: broadcastStatus,
+        isElectronDevRuntime: () => dev,
+        serveObsStaticFile: serveStaticFile,
+    });
+    const server = http.createServer((req, res) => {
+        void handler(req, res).catch(error => res.destroy(error));
+    });
+    activeServers.push(server);
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            resolve();
+        });
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing OBS test port.');
+    port = address.port;
+    return { baseUrl: `http://127.0.0.1:${port}`, port, clients, matchesToken, broadcastStatus, serveStaticFile };
+};
+
+describe('OBS browser source HTTP boundary', () => {
+    it.each([
+        { enabled: true, token: 'private-obs-token' },
+        { enabled: false, token: 'retained-disabled-token' },
+        { enabled: true, token: null },
+    ])('only publishes health fields with enabled=$enabled and token=$token', async options => {
+        const api = await startServer(options);
+        const response = await fetch(`${api.baseUrl}/obs/health`, {
+            headers: { Origin: 'https://untrusted.example' },
+        });
+        expect(response.status).toBe(200);
+        expect(response.headers.get('access-control-allow-origin')).toBe('*');
+        expect(response.headers.get('cache-control')).toBe('no-store');
+        expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+        expect(await response.json()).toEqual({ enabled: options.enabled, port: api.port, clientCount: 0 });
+        expect(api.matchesToken).not.toHaveBeenCalled();
+        expect(api.serveStaticFile).not.toHaveBeenCalled();
+    });
+
+    it('does not reflect credential-shaped query parameters in public health', async () => {
+        const api = await startServer();
+        const response = await fetch(`${api.baseUrl}/obs/health?token=private-obs-token&url=secret&includeToken=true`);
+        expect(await response.json()).toEqual({ enabled: true, port: api.port, clientCount: 0 });
+    });
+
+    it.each(['/obs', '/obs/events'])('rejects missing and incorrect tokens on %s', async pathname => {
+        const api = await startServer();
+        for (const query of ['', '?token=wrong', '?token=', '?token=wrong&token=private-obs-token']) {
+            const response = await fetch(`${api.baseUrl}${pathname}${query}`);
+            expect(response.status).toBe(401);
+            expect(await response.json()).toEqual({ error: 'Unauthorized.' });
+        }
+        expect(api.clients.size).toBe(0);
+        expect(api.serveStaticFile).not.toHaveBeenCalled();
+    });
+
+    it('health cannot supply a credential that unlocks the event stream', async () => {
+        const api = await startServer();
+        const health = await fetch(`${api.baseUrl}/obs/health`).then(response => response.json());
+        const response = await fetch(`${api.baseUrl}/obs/events?token=${encodeURIComponent(String(health.token ?? ''))}`);
+        expect(response.status).toBe(401);
+        await response.body?.cancel();
+    });
+
+    it('serves the packaged source page with a valid token', async () => {
+        const api = await startServer();
+        const response = await fetch(`${api.baseUrl}/obs?obs=1&token=private-obs-token`);
+        expect(response.status).toBe(200);
+        expect(await response.text()).toContain('OBS source');
+        expect(api.serveStaticFile).toHaveBeenCalledOnce();
+    });
+
+    it('preserves the authenticated development redirect and encoded token', async () => {
+        const token = 'private /+& token';
+        const api = await startServer({ dev: true, token });
+        const response = await fetch(`${api.baseUrl}/obs?token=${encodeURIComponent(token)}`, { redirect: 'manual' });
+        expect(response.status).toBe(302);
+        const target = new URL(response.headers.get('location')!);
+        expect(target.origin).toBe('http://localhost:3000');
+        expect(target.searchParams.get('token')).toBe(token);
+        expect(target.searchParams.get('obs')).toBe('1');
+        expect(target.searchParams.get('obsPort')).toBe(String(api.port));
+        expect(api.serveStaticFile).not.toHaveBeenCalled();
+        await response.body?.cancel();
+    });
+
+    it('streams to an authenticated client and reports its connection without exposing credentials', async () => {
+        const api = await startServer();
+        const response = await fetch(`${api.baseUrl}/obs/events?token=private-obs-token`);
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toBe('text/event-stream; charset=utf-8');
+        const reader = response.body!.getReader();
+        try {
+            const { value } = await reader.read();
+            expect(new TextDecoder().decode(value)).toContain('event: config');
+            const health = await fetch(`${api.baseUrl}/obs/health`).then(result => result.json());
+            expect(health).toEqual({ enabled: true, port: api.port, clientCount: 1 });
+            expect(api.broadcastStatus).toHaveBeenCalledOnce();
+        } finally {
+            await reader.cancel();
+        }
+        await vi.waitFor(() => expect(api.clients.size).toBe(0));
+        expect(api.broadcastStatus).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps protected routes unavailable when the source is disabled', async () => {
+        const api = await startServer({ enabled: false });
+        for (const pathname of ['/obs', '/obs/events']) {
+            const response = await fetch(`${api.baseUrl}${pathname}?token=private-obs-token`);
+            expect(response.status).toBe(503);
+            expect(await response.json()).toEqual({ error: 'OBS browser source is disabled.' });
+        }
+        expect(api.serveStaticFile).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
The public `GET /obs/health` response included the OBS access token and token-bearing source URL. It now returns only `enabled`, `port`, and `clientCount`.

The HTTP handler is extracted into `electron/obsBrowserSourceHttp.cjs` so regression tests can exercise real loopback HTTP requests without starting Electron. The tests cover health responses while enabled/disabled, credential-shaped query parameters, the health-to-event-stream attack, token rejection, authenticated SSE lifecycle, and the development redirect.

Validation:
- Reproduced the disclosure against the extracted original handler: six regression cases failed, including a health-derived token receiving HTTP 200 from the event stream.
- `node --check electron/main.cjs` and `node --check electron/obsBrowserSourceHttp.cjs`: passed.
- Focused OBS/HTTP tests: 85 passed.
- `npm run typecheck`: passed.
- `npm run test:unit`: 3,306 passed, 1 existing skipped test.

Upgrade guidance: users who previously enabled this feature should select **Regenerate Token** in the OBS browser source settings, toggle the source off and on to close existing streams, and replace the source URL in OBS.
